### PR TITLE
Basic YARP-DFT at the ND CRC

### DIFF
--- a/pyTEST_Example/crc_at_nd/TS_refine.py
+++ b/pyTEST_Example/crc_at_nd/TS_refine.py
@@ -14,11 +14,52 @@ Tags to include in parameters.yaml:
 
 input : str
     Path to either an XYZ file or a folder filled with XYZ files
+    TO-DO: add error if missing from input
 
 dft_lot : str
     Level of theory (lot) desired to run density functional theory (DFT) at.
     TO-DO: what are acceptable inputs here????
+    dft_lot: wB97X D4 def2-TZVP # the functional and basis set for DFT
+    TO-DO: add default if missing from input
 
+scratch : str
+    Folder that output files will be placed
+    TO-DO: add default if missing from input
+
+package : str
+    Software package (ORCA, Gaussian) to perform DFT with.
+    Currently only ORCA is available!
+
+dft_nprocs : int
+    Number of CPUs available for each DFT calculation.
+
+mem : int
+    Memory (in GB) available for each DFT calculation.
+
+charge : int
+    Overall charge of molecule(s).
+    This will be applied to all molecules in a batch submission.
+
+multiplicity : int
+    Spin multiplicity of molecule(s).
+    This will be applied to all molecules in a batch submission.
+
+solvent : ?????
+    Turn implicit solvation on/off
+    TO-DO: figure out what this should look like!
+
+solvation_model : str
+    Keyword for ORCA solvent model.
+    TO-DO: describe how to find eligible inputs here.
+
+dielectric : float
+    Dielectric constant for implicit solvation.
+    Modify this to match the solvent of choice.
+
+dft_njobs : int
+    Number of DFT jobs to be submitted.
+    TO-DO: figure out the nuance of this interaction with "running_jobs"
+    This will not always be the actual number of jobs submitted?
 """
 
 import sys
@@ -32,38 +73,114 @@ import fnmatch
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from yarp.input_parsers import xyz_parse
+from utils import xyz_write
 from wrappers.orca import ORCA
-from job_submission import *
-
+from job_submission import QSE_jobs
 
 def main(args):
 
-    # Read energies and atomic cartesian coordinates (geometries) of TS inputs into a dictionary
+    # Read energies and atomic cartesian coordinates (geometries) of input XYZ files into a dictionary
     TS_dict=dict()
     
     if os.path.isfile(args["input"]):
         # For a single XYZ file
         energy, geom = xyz_parse(args["input"])
-        TS_dict[args["input"].split("/")[-1].split(".")[0]] = dict()
+        TS_dict[args["input"].split("/")[-1].split(".")[0]] = dict() # store XYZ filename
         TS_dict[args["input"].split("/")[-1].split(".")[0]]["E"] = energy
         TS_dict[args["input"].split("/")[-1].split(".")[0]]["TSG"] = geom
     else:
         # For a directory of multiple XYZ files
-        xyz_files=[args["input"]+"/"+i for i in os.listdir(args["input"]) if fnmatch.fnmatch(i, "*.xyz")]
+        xyz_files = [args["input"]+"/"+i for i in os.listdir(args["input"]) if fnmatch.fnmatch(i, "*.xyz")]
         for i in xyz_files:
             energy, geom = xyz_parse(i)
-            TS_dict[i.split("/")[-1].split(".")[0]]=dict()
+            TS_dict[i.split("/")[-1].split(".")[0]] = dict() # store XYZ filename
             TS_dict[i.split("/")[-1].split(".")[0]]["E"] = energy
             TS_dict[i.split("/")[-1].split(".")[0]]["TSG"] = geom
     
+    # Set up location to put output files
+    scratch = args["scratch"]
+    os.makedirs(scratch, exist_ok=True)
+
     # Read in DFT level of theory (lot) from input file
-    # Join phrases together if multiple words provided
-    if len(args["dft_lot"].split()) > 1: dft_lot="/".join(args["dft_lot"].split())
-    else: dft_lot=args["dft_lot"]
-    
+    # Join phrases together if multiple words are provided
+    # ERM: only needed for Gaussian???? comment out for now :(
+    # if len(args["dft_lot"].split()) > 1: dft_lot="/".join(args["dft_lot"].split())
+    # else: dft_lot=args["dft_lot"]
+
+    # Set up DFT input files for each TS object
+    job_list = dict()
+    running_jobs = []
+
+    for i in TS_dict.keys():
+        # Create a folder associated with each input file name
+        wf = os.path.join(scratch, i)
+        os.makedirs(wf, exist_ok=True)
+
+        # Generate an XYZ file for each input
+        xyz_file = os.path.join(wf, f"{i}.xyz")
+        xyz_write(xyz_file, TS_dict[i]["E"], TS_dict[i]["TSG"])
+
+        # Conditional tree for different DFT packages
+        if args["package"] == "ORCA":
+            # Initialize ORCA class object
+            dft_job = ORCA(
+                input_geo = xyz_file,
+                work_folder = wf,
+                nproc = int(args["dft_nprocs"]),
+                mem = int(args["mem"])*1000,
+                jobname = f"{i}-TSOPT",
+                jobtype = "OptTS Freq",
+                lot = args["dft_lot"],
+                charge = args["charge"],
+                multiplicity = args["multiplicity"],
+                solvent = args["solvent"],
+                solvation_model = args["solvation_model"],
+                dielectric = args["dielectric"],
+                writedown_xyz = True
+            )
+
+            # Generate input file
+            dft_job.generate_geometry_settings(hess = True, hess_step = int(args["hess_recalc"]))
+            dft_job.generate_input()
+
+            # Save ORCA object for use later
+            # ERM: Do I need to use this later, actually????
+            job_list[i]=dft_job
+
+            # Check if a completed job is present before adding to the list of jobs to run
+            if dft_job.calculation_terminated_normally() is False: running_jobs.append(i)
+        else :
+            raise RuntimeError("It's ORCA or bust right now my friend, sorry!")
+
+    # Conditional tree to submit DFT jobs after checking for already completed jobs
+    if len(running_jobs) > 1 :
+        # Do something clever to determine how many jobs to submit
+        # TO-DO: figure out this black magic!
+        n_jobs = len(running_jobs) // int(args["dft_njobs"])
+        if len(running_jobs) % int(args["dft_njobs"]) > 0 :
+            n_jobs += 1
+
+        # Generate a single QSE job array submission script for all DFT jobs to be submitted
+        all_dft_jobs = QSE_jobs(
+            jobname = args["package"],
+            module = "module load orca", # TO-DO: make this a user input
+            submit_path = scratch, # QSE script is at same level as all XYZ repos!
+            queue = "long",
+            ncpus = int(args["dft_nprocs"]),
+            ntasks = n_jobs,
+        )
+        all_dft_jobs.prepare_submission_script()
+
+        # Submit stuff to the queue! (ERM: turn on after testing out whether things generate properly)
+        # all_dft_jobs.submit()
+    else:
+        print("Looks like you've already done all the TS optimizations!")
+
     return
 
-if __name__=="__main__":
+if __name__ == "__main__":
     parameters = sys.argv[1]
-    parameters = yaml.load(open(parameters, "r"), Loader=yaml.FullLoader)
+    with open(parameters, "r") as file:
+        parameters = yaml.safe_load(file)
+
     main(parameters)

--- a/pyTEST_Example/crc_at_nd/TS_refine.py
+++ b/pyTEST_Example/crc_at_nd/TS_refine.py
@@ -165,16 +165,24 @@ def main(args): # TO-DO: use yaml to robustly handle input from args
     n_jobs = len(running_jobs)
 
     print(f"Running {n_jobs} jobs!")
-    # Generate a single QSE job array submission script for all DFT jobs to be submitted
-    all_dft_jobs = QSE_jobs(
-        package = args["package"],
-        jobname = job_file_name,
-        module = "module load orca\n", # TO-DO: make this a user input
-        submit_path = scratch, # QSE script is at same level as all XYZ repos!
-        queue = "long",
-        ncpus = int(args["dft_nprocs"]),
-        ntasks = n_jobs
-    )
+
+    if args["scheduler"] == "QSE" :
+        # Generate a single QSE job array submission script for all DFT jobs to be submitted
+        all_dft_jobs = QSE_jobs(
+            package = args["package"],
+            jobname = job_file_name,
+            module = "module load orca\n", # TO-DO: make this a user input
+            submit_path = scratch, # QSE script is at same level as all XYZ repos!
+            queue = "long",
+            ncpus = int(args["dft_nprocs"]),
+            ntasks = n_jobs
+        )
+    elif args["scheduler"] == "condor" :
+        all_dft_jobs = "bob"
+        raise RuntimeError("Condor is a work in progress!")
+    else :
+        raise RuntimeError("Sorry, only QSE or condor are valid entries in scheduler!")
+
     all_dft_jobs.prepare_submission_script()
 
     # Submit stuff to the queue! (ERM: turn on after testing out whether things generate properly)

--- a/pyTEST_Example/crc_at_nd/TS_refine.py
+++ b/pyTEST_Example/crc_at_nd/TS_refine.py
@@ -1,0 +1,69 @@
+"""
+This program aims to refine the transition states (TS) of a collection of XYZ files
+using ORCA to perform DFT level TS optimizations.
+
+To use this script:
+
+```
+conda activate classy-yarp
+python TS_refine.py parameters.yaml
+```
+
+Tags to include in parameters.yaml:
+-----------------------------------
+
+input : str
+    Path to either an XYZ file or a folder filled with XYZ files
+
+dft_lot : str
+    Level of theory (lot) desired to run density functional theory (DFT) at.
+    TO-DO: what are acceptable inputs here????
+
+"""
+
+import sys
+import os
+import yaml
+import fnmatch
+
+# Add the parent directory to the system path
+# Now python should be able to find other python module files,
+# even if they live in the parent directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from yarp.input_parsers import xyz_parse
+from wrappers.orca import ORCA
+from job_submission import *
+
+
+def main(args):
+
+    # Read energies and atomic cartesian coordinates (geometries) of TS inputs into a dictionary
+    TS_dict=dict()
+    
+    if os.path.isfile(args["input"]):
+        # For a single XYZ file
+        energy, geom = xyz_parse(args["input"])
+        TS_dict[args["input"].split("/")[-1].split(".")[0]] = dict()
+        TS_dict[args["input"].split("/")[-1].split(".")[0]]["E"] = energy
+        TS_dict[args["input"].split("/")[-1].split(".")[0]]["TSG"] = geom
+    else:
+        # For a directory of multiple XYZ files
+        xyz_files=[args["input"]+"/"+i for i in os.listdir(args["input"]) if fnmatch.fnmatch(i, "*.xyz")]
+        for i in xyz_files:
+            energy, geom = xyz_parse(i)
+            TS_dict[i.split("/")[-1].split(".")[0]]=dict()
+            TS_dict[i.split("/")[-1].split(".")[0]]["E"] = energy
+            TS_dict[i.split("/")[-1].split(".")[0]]["TSG"] = geom
+    
+    # Read in DFT level of theory (lot) from input file
+    # Join phrases together if multiple words provided
+    if len(args["dft_lot"].split()) > 1: dft_lot="/".join(args["dft_lot"].split())
+    else: dft_lot=args["dft_lot"]
+    
+    return
+
+if __name__=="__main__":
+    parameters = sys.argv[1]
+    parameters = yaml.load(open(parameters, "r"), Loader=yaml.FullLoader)
+    main(parameters)

--- a/pyTEST_Example/job_submission.py
+++ b/pyTEST_Example/job_submission.py
@@ -447,7 +447,7 @@ class QSE_jobs:
             if self.package == "ORCA" :
                 f.write("    echo Loading ORCA\n")
                 # Put in module load commands
-                f.write(f"{self.module}")
+                f.write(f"    {self.module}")
                 # Set up full path to ORCA for paralleliztion runs
                 f.write("    orca=$(which orca)\n")
                 # Execute ORCA input file
@@ -603,7 +603,7 @@ class CONDOR_jobs:
             if self.package == "ORCA" :
                 f.write("    echo Loading ORCA\n")
                 # Put in module load commands
-                f.write(f"{self.module}")
+                f.write(f"    {self.module}")
                 # Set up full path to ORCA for paralleliztion runs
                 f.write("    orca=$(which orca)\n")
                 # Execute ORCA input file

--- a/pyTEST_Example/job_submission.py
+++ b/pyTEST_Example/job_submission.py
@@ -358,6 +358,8 @@ class QSE_jobs:
 
     Planning Notes
     --------------
+    IMPORTANT: Need to improve robustness of the ORCA input/output file formatting!!!
+
     How do I documment the class functions?
 
     Have most things figured out for ORCA. Not yet set up for CREST/Gaussian.
@@ -448,7 +450,7 @@ class QSE_jobs:
                 f.write("orca=$(which orca)\n")
                 # Execute ORCA input file
                 # ERM: Need to figure out what these files will be named!!!
-                f.write("$orca orca.inp > orca.out\n")
+                f.write("$orca orcajob.in > orcajob.out\n")
             elif self.jobname == "CREST" :
                 # ERM : Not available from module load, but should work by activating classy YARP conda environment!?
                 f.write("CREST stuff\n")

--- a/pyTEST_Example/job_submission.py
+++ b/pyTEST_Example/job_submission.py
@@ -441,28 +441,28 @@ class QSE_jobs:
             f.write('    exec > "${folder_array[$SGE_TASK_ID-1]}/output.log" 2> "${folder_array[$SGE_TASK_ID-1]}/error.log"\n')
 
             # Change to folder of interest
-            f.write("cd ${folder_array[$SGE_TASK_ID-1]}\n")
+            f.write("    cd ${folder_array[$SGE_TASK_ID-1]}\n")
 
             # Put in script body according to jobname input
             if self.package == "ORCA" :
-                f.write("echo Loading ORCA\n")
+                f.write("    echo Loading ORCA\n")
                 # Put in module load commands
                 f.write(f"{self.module}")
                 # Set up full path to ORCA for paralleliztion runs
-                f.write("orca=$(which orca)\n")
+                f.write("    orca=$(which orca)\n")
                 # Execute ORCA input file
                 # ERM: Need to figure out what these files will be named!!!
-                f.write(f"echo Executing ORCA job from $PWD\n")
-                f.write(f"$orca {self.jobname}.in > {self.jobname}.out\n")
+                f.write(f"    echo Executing ORCA job from $PWD\n")
+                f.write(f"    $orca {self.jobname}.in > {self.jobname}.out\n")
             elif self.package == "CREST" :
                 # ERM : Not available from module load, but should work by activating classy YARP conda environment!?
-                f.write("CREST stuff\n")
+                f.write("    CREST stuff\n")
             else:
                 # Throw a runtime error
                 raise RuntimeError("QSE class currently only supports CREST and ORCA job submissions!")
 
             # Return to previous folder
-            f.write('cd "$base_dir"\n')
+            f.write('    cd "$base_dir"\n')
 
             # Close the "does this directory exist?" bash conditional
             f.write('else\n')
@@ -488,6 +488,169 @@ class QSE_jobs:
         
         # Execute job submission via qsub
         command = f"qsub {self.script_file}"
+        output = subprocess.run(command, shell=True, capture_output=True, text=True)
+        
+        # save job ID somehow....
+        # self.job_id = output.stdout.split()[-1] # need to modify this!??
+
+
+class CONDOR_jobs:
+    """
+    Base class to manage submission of external jobs to HT Condor resource manager.
+
+    Attributes
+    ----------
+    jobname : str
+        Flag to control whether QSE submission script is generated to run ORCA, CREST, or
+        some other package. Currently only accepts "ORCA" or "CREST".
+
+    module : str
+        Command line input to load external software.
+        For example, if ORCA job is wanted, this should be "module load orca".
+        Syntax will depend on the cluster system running on.
+        So we need to make this as flexible as possible.
+
+    submit_path : str
+        Directory from which submission script will be executed.
+        Defaults to current working directory.
+
+    queue : str
+        Queue to submit job requests to. Default is general CPU queue at ND-CRC (long).
+        Eventually, this should probably be the Savoie group's specific queue at ND-CRC.
+        There's also a GPU queue, but YARP is for CPUs right now, not GPUs.
+
+    ncpus : int
+        Number of CPUs used to parallelize across for each QSE job instance.
+        Defaults to 1 CPU.
+
+    ntasks : int
+        Number of tasks contained in the job array.
+        Defaults to 1 task.
+
+    email : str
+        Email to send "abort, begin, end" updates to for submitted jobs.
+        Default is to not include this in submission script.
+
+    script_file : str
+        Path to QSE submission script.
+
+    job_id : ???
+        Holder for QSE job ID generated after submission.
+
+    Planning Notes
+    --------------
+    IMPORTANT: Need to improve robustness of the ORCA input/output file formatting!!!
+
+    How do I documment the class functions?
+
+    Have most things figured out for ORCA. Not yet set up for CREST/Gaussian.
+    CREST is a priority. Gaussian will happen when it happens.
+
+    Submission of jobs must be done on a frontend login node at ND-CRC. Therefore,
+    we are limited to only execute the job submission script for 1 hour wall time.
+    Need to add a routine for limiting walltime, so we don't get shutdown by the CRC staff.
+    UPDATE: Turns out the 1 hour wall time is a soft limit set by the CRC staff.
+    This is therefore an optional "nice to have", rather than a necessity.
+
+    """
+
+    # Constructor
+    def __init__(self, package = "ORCA", jobname = "JobSubmission", module = "module load orca", submit_path = os.getcwd(), queue = "long", ncpus = 1, ntasks = 1, email= ""):
+
+        # Required inputs (based on Notre Dame's Center for Research Computing requirements!)
+        self.ncpus = ncpus
+        self.queue = queue
+        self.ntasks = ntasks
+
+        self.jobname = jobname
+        self.package = package
+        self.module = module # line needed to load the necessary software
+        self.submit_path = submit_path # assumes input files have already been generated in this location!
+
+        self.email = email
+
+        # Derived attributes
+        self.script_file = os.path.join(submit_path, jobname+'_conda.submit')
+        self.executable_file = os.path.join(submit_path, jobname+'.sh')
+        self.job_id = None
+
+    def prepare_submission_script(self):
+        """
+        Create a CONDOR submission script based on inputs from class initialization
+        """
+        with open(self.executable_file, "w") as f:
+            f.write("#!/bin/bash\n")
+
+            # Collect info on compute resources
+            f.write("echo Running on host `hostname`\n")
+            f.write("echo Start Time is `date`\n\n")
+            f.write("base_dir=$(PWD)\n")
+
+            # ERM: Pretty sure this routine won't be needed because of the initialdir functionality
+            # # Collect a list of folders to iterate through
+            # f.write("mapfile -t folder_array < <(find . -maxdepth 1 -type d ! -name '.' -exec basename {} \;)\n")
+
+            # # Open a "does this directory exist?" bash conditional
+            # f.write('if [ -d "${folder_array[$SGE_TASK_ID-1]}" ]; then\n')
+
+            # # Redirect output and error to the appropriate folder
+            # f.write('    exec > "${folder_array[$SGE_TASK_ID-1]}/output.log" 2> "${folder_array[$SGE_TASK_ID-1]}/error.log"\n')
+
+            # # Change to folder of interest
+            # f.write("    cd ${folder_array[$SGE_TASK_ID-1]}\n")
+
+            # Put in script body according to jobname input
+            if self.package == "ORCA" :
+                f.write("    echo Loading ORCA\n")
+                # Put in module load commands
+                f.write(f"{self.module}")
+                # Set up full path to ORCA for paralleliztion runs
+                f.write("    orca=$(which orca)\n")
+                # Execute ORCA input file
+                # ERM: Need to figure out what these files will be named!!!
+                f.write(f"    echo Executing ORCA job from $PWD\n")
+                f.write(f"    $orca {self.jobname}.in > {self.jobname}.out\n")
+            elif self.package == "CREST" :
+                # ERM : Not available from module load, but should work by activating classy YARP conda environment!?
+                f.write("    CREST stuff\n")
+            else:
+                # Throw a runtime error
+                raise RuntimeError("QSE class currently only supports CREST and ORCA job submissions!")
+
+            # Return to previous folder
+            f.write('    cd "$base_dir"\n')
+
+            # Close the "does this directory exist?" bash conditional
+            f.write('else\n')
+            f.write('    echo "Error: Directory ${folder_array[$SGE_TASK_ID-1]} does not exist" > "error_job_${JOB_ID}_task_${SGE_TASK_ID}.log"\n')
+            f.write('fi\n')
+
+            # Make script footer
+            f.write("\necho End Time is `date`\n\n")
+
+
+        with open(self.script_file, "w") as f:
+            f.write("universe = vanilla\n")
+            f.write("getenv = true\n")
+            
+
+
+    def submit(self):
+        """
+        Submit a CONDOR job array using the previously built script file 
+
+        Save job IDs to class variable for access later
+
+        To-do's:
+        - update jobID parsing to distinguish between base job number and task ID
+        - figure out a good default to use for self.job_id initialization
+        """
+        os.chdir(self.submit_path)
+        current_dir = os.getcwd()
+        print(f"Submitting jobs from {current_dir}")
+        
+        # Execute job submission via qsub
+        command = f"condor_submit {self.script_file}"
         output = subprocess.run(command, shell=True, capture_output=True, text=True)
         
         # save job ID somehow....


### PR DESCRIPTION
# Overall To-Do List

- [x]  Implement QSE job class to manage QSE interface (tailored for ND-CRC settings)
- [ ]  Develop `main_dft.py` alternatives
  - [x] TS refinement script
  - [ ] Others?
- [ ]  Add unit testing routines to ensure correct formatting of QSE job submission scripts

# Specs and Requirements

- We only need to be able to run DFT jobs using ORCA and Gaussian via the QSE resource manager.
  - The main_xtb.py script currently works, as is.
- Job submissions at ND-CRC must occur on a frontend node, with a limit of 1 hour walltime for script execution
  - Therefore the current main_dft.py script must be modified, as it currently holds until the TS refinement stage is completed, which can easily exceed this walltime limit
- Submitting more than 50 jobs at once must be done using the job array functionality of QSE
  - This will require a re-work of the current SLURM job submission flow. One script will be generated for *all* jobs, rather than each job having its own script
- Unit testing to ensure that files are properly generated/formatted
  - Figure out how to automatically delete generated files after testing
  - Out of scope to actually submit files to job scheduler as part of the unit testing
- Unit testing should be integrated into the pipeline.
