### PR TITLE
Refine conformer selection logic

### DIFF
--- a/yarp/reaction/conf_sampling/select_pairs.py
+++ b/yarp/reaction/conf_sampling/select_pairs.py
@@ -17,9 +17,13 @@ def select_gsm_pairs(rxn, config):
     """
     Orchestrates Biasing -> Alignment -> ML Tournament -> QC -> Pairing.
     """
-    r_confs = list(rxn.reactant.conformers.values())
-    p_confs = list(rxn.product.conformers.values())
-    
+#    r_confs = list(rxn.reactant.conformers.values())
+#    p_confs = list(rxn.product.conformers.values())
+
+
+    r_confs = [conf for key, conf in rxn.reactant.conformers.items() if key != "initial_geom"]    # SHQK : The original raw input geometry of the reactant/product should not be included for pair selection once conf_sampling is performed. In case NO conformer sampling is requested (currently this is not an option, the default is to perform conf_sampling for both reacatnt and product), a condition can be added later to keep "initial_geom" because that will be the only option to perform "select_gsm_pairs" with. 
+    p_confs = [conf for key, conf in rxn.product.conformers.items() if key != "initial_geom"]    # SHQK : The original raw input geometry of the reactant/product should not be included for pair selection once conf_sampling is performed. In case NO conformer sampling is requested (currently this is not an option, the default is to perform conf_sampling for both reacatnt and product), a condition can be added later to keep "initial_geom" because that will be the only option to perform "select_gsm_pairs" with.
+
     # --- STEP A: Apply Joint Optimization (Biasing) ---
     lot = config.bias_lot
     mode = config.joint_opt.lower()
@@ -33,13 +37,14 @@ def select_gsm_pairs(rxn, config):
     if mode in ['dual', 'p_only']:
         biased_r = [ob_joint_optimize(c, rxn.product.paired_bem, lot) for c in p_confs]
 
+
     # --- STEP B: Cross-Product Evaluation & Tournament ---
     # ERM: We'll see... this is probably an unacceptable bottleneck...
 
     # Default to "conformation-poor" model, unless an excess of conformers is present
     n_conf = config.n_conf
     total_conf = len(r_confs) + len(p_confs)
-    verbose = getattr(config, "verbose", False)
+    verbose = getattr(config, "verbose", True)
     if verbose:
         print("Total number of reactant + product conformers generated = ", total_conf)
 
@@ -54,69 +59,118 @@ def select_gsm_pairs(rxn, config):
     with open(model_path, 'rb') as f:
         model = pickle.load(f)
 
+    # Truncate both the original and biased lists when the conformer pool is too large compared to the number of rxn conformers requested
+    limit = n_conf * 5
+    if len(r_confs) > limit:
+        r_confs = r_confs[:limit]    # SHQK : It is important to truncate the original conformer list as well to avoid list indexing error arising due to 1:1 matching in the M+N algorithm
+        biased_p = biased_p[:limit]
+    if len(p_confs) > limit:
+        p_confs = p_confs[:limit]    # SHQK : It is important to truncate the original conformer list as well to avoid list indexing error arising due to 1:1 matching in the M+N algorithm
+        biased_r = biased_r[:limit]
 
-    if len(biased_r) > n_conf * 5:
-        biased_r = biased_r[:n_conf * 5]
-    if len(biased_p) > n_conf * 5:
-        biased_p = biased_p[:n_conf * 5]
 
+    # --- STEP C: Cross-Product Evaluation & Tournament ---
+    # SHQK : Replacing the M*N evaluation loop with a 1:1 (M+N) index-matching approach in the following. The previous M*N approach was not only an inefficient bottleneck, but also incorrectly implemented
     approved_pairs = []
     approved_indicators = []
-    for r_c in biased_r:
-        for p_c in biased_p:
-            
+    dropped_pairs = 0
+
+    for ind, r_c in enumerate(r_confs):
+#        for p_c in biased_p:
+         
             # 1. Unaligned Evaluation
-            ind_unaligned = return_indicator(E=r_c.elements, RG=r_c.geo, PG=p_c.geo)
+            ind_unaligned = return_indicator(E=r_c.elements, RG=r_c.geo, PG=biased_p[ind].geo)
             prob_unaligned = model.predict_proba(ind_unaligned)
-            
+
             # 2. Aligned Evaluation
-            aligned_p_c = align_conformers(r_c, p_c)
-            ind_aligned = return_indicator(E=r_c.elements, RG=r_c.geo, PG=aligned_p_c.geo)
+            aligned_biased_p = align_conformers(r_c, biased_p[ind])
+            ind_aligned = return_indicator(E=r_c.elements, RG=r_c.geo, PG=aligned_biased_p.geo)
             prob_aligned = model.predict_proba(ind_aligned)
-            
+
             # 3. The Tournament (keep the higher probability setup)
             if prob_aligned[0][1] > prob_unaligned[0][1]:
-                best_p = aligned_p_c
+                best_p = aligned_biased_p
                 best_ind = ind_aligned
                 best_prob = prob_aligned
             else:
-                best_p = p_c
+                best_p = biased_p[ind]
                 best_ind = ind_unaligned
                 best_prob = prob_unaligned
-            
+
             # 4. Quality Control & Deduplication
             if best_prob[0][1] > 0.0 and check_uniqueness(best_ind, approved_indicators):
                 approved_indicators.append(best_ind)
                 approved_pairs.append({
                     "r_conf": r_c,
                     "p_conf": best_p,
+                    "score": best_prob[0][1]    # SHQK : Or best_prob[0][0]??. [0][1] is correct in this case, as later the pairs are stored in descending order (reverse=True).
+                })
+            else:   # SHQK : Debugging..... 
+                dropped_pairs += 1
+
+####################################################################
+    for ind, p_c in enumerate(p_confs):
+#        for p_c in biased_p:
+
+            # 1. Unaligned Evaluation
+            ind_unaligned = return_indicator(E=r_c.elements, RG=p_c.geo, PG=biased_r[ind].geo)
+            prob_unaligned = model.predict_proba(ind_unaligned)
+
+            # 2. Aligned Evaluation
+            aligned_biased_r = align_conformers(p_c, biased_r[ind])
+            ind_aligned = return_indicator(E=r_c.elements, RG=p_c.geo, PG=aligned_biased_r.geo)
+            prob_aligned = model.predict_proba(ind_aligned)
+
+            # 3. The Tournament (keep the higher probability setup)
+            if prob_aligned[0][1] > prob_unaligned[0][1]:
+                best_r = aligned_biased_r
+                best_ind = ind_aligned
+                best_prob = prob_aligned
+            else:
+                best_r = biased_r[ind]
+                best_ind = ind_unaligned
+                best_prob = prob_unaligned
+
+            # 4. Quality Control & Deduplication
+            if best_prob[0][1] > 0.0 and check_uniqueness(best_ind, approved_indicators):
+                approved_indicators.append(best_ind)
+                approved_pairs.append({
+                    "r_conf": best_r,
+                    "p_conf": p_c,
                     "score": best_prob[0][1]
                 })
+            else:    # SHQK : Debugging.....
+                dropped_pairs += 1
 
-    # --- STEP C: Sort and Select Top N ---
+    # --- STEP D: Sort and Select Top N ---
     # Sort descending by probability of success
     approved_pairs.sort(key=lambda x: x["score"], reverse=True)
 
+    if verbose:
+        print("Number of approved pairs = ", len(approved_pairs))
+        print("Number of dropped pairs = ", dropped_pairs)
+##############################################################################
     # Truncate to the number requested by the user
     return approved_pairs[:n_conf]
 
 
-def align_conformers(r_conf, p_conf):
+def align_conformers(conf, biased_conf):
     """
     Uses ASE to minimize rotation and translation (RMSD) between product and reactant.
     Returns a NEW product conformer that is aligned to the reactant.
     """
-    r_atoms = Atoms(symbols=[el.upper() for el in r_conf.elements], positions=r_conf.geo)
-    p_atoms = Atoms(symbols=[el.upper() for el in r_conf.elements], positions=p_conf.geo)
+    atoms = Atoms(symbols=[el.upper() for el in conf.elements], positions=conf.geo)
+    biased_atoms = Atoms(symbols=[el.upper() for el in conf.elements], positions=biased_conf.geo)
 
     # ASE modifies the moving atoms (p_atoms) in-place to align with the target (r_atoms)
-    minimize_rotation_and_translation(r_atoms, p_atoms)
+    minimize_rotation_and_translation(atoms, biased_atoms)
 
-    aligned_p_conf = copy.deepcopy(p_conf)
-    aligned_p_conf.geo = p_atoms.positions # Extract the rotated/translated coordinates
-    aligned_p_conf.type = f"aligned_{p_conf.type}"
+    aligned_biased_conf = copy.deepcopy(biased_conf)
+    aligned_biased_conf.geo = biased_atoms.positions # Extract the rotated/translated coordinates
+    aligned_biased_conf.type = f"aligned_{biased_conf.type}"
 
-    return aligned_p_conf
+    return aligned_biased_conf
+
 
 def check_uniqueness(new_indicators, approved_indicators_list, threshold=0.025):
     """

--- a/yarp/reaction/conf_sampling/select_pairs.py
+++ b/yarp/reaction/conf_sampling/select_pairs.py
@@ -17,12 +17,8 @@ def select_gsm_pairs(rxn, config):
     """
     Orchestrates Biasing -> Alignment -> ML Tournament -> QC -> Pairing.
     """
-#    r_confs = list(rxn.reactant.conformers.values())
-#    p_confs = list(rxn.product.conformers.values())
-
-
-    r_confs = [conf for key, conf in rxn.reactant.conformers.items() if key != "initial_geom"]    # SHQK : The original raw input geometry of the reactant/product should not be included for pair selection once conf_sampling is performed. In case NO conformer sampling is requested (currently this is not an option, the default is to perform conf_sampling for both reacatnt and product), a condition can be added later to keep "initial_geom" because that will be the only option to perform "select_gsm_pairs" with. 
-    p_confs = [conf for key, conf in rxn.product.conformers.items() if key != "initial_geom"]    # SHQK : The original raw input geometry of the reactant/product should not be included for pair selection once conf_sampling is performed. In case NO conformer sampling is requested (currently this is not an option, the default is to perform conf_sampling for both reacatnt and product), a condition can be added later to keep "initial_geom" because that will be the only option to perform "select_gsm_pairs" with.
+    r_confs = [conf for key, conf in rxn.reactant.conformers.items() if key != "initial_geom"] 
+    p_confs = [conf for key, conf in rxn.product.conformers.items() if key != "initial_geom"]
 
     # --- STEP A: Apply Joint Optimization (Biasing) ---
     lot = config.bias_lot
@@ -37,14 +33,10 @@ def select_gsm_pairs(rxn, config):
     if mode in ['dual', 'p_only']:
         biased_r = [ob_joint_optimize(c, rxn.product.paired_bem, lot) for c in p_confs]
 
-
-    # --- STEP B: Cross-Product Evaluation & Tournament ---
-    # ERM: We'll see... this is probably an unacceptable bottleneck...
-
     # Default to "conformation-poor" model, unless an excess of conformers is present
     n_conf = config.n_conf
     total_conf = len(r_confs) + len(p_confs)
-    verbose = getattr(config, "verbose", True)
+    verbose = getattr(config, "verbose", False)
     if verbose:
         print("Total number of reactant + product conformers generated = ", total_conf)
 
@@ -62,21 +54,19 @@ def select_gsm_pairs(rxn, config):
     # Truncate both the original and biased lists when the conformer pool is too large compared to the number of rxn conformers requested
     limit = n_conf * 5
     if len(r_confs) > limit:
-        r_confs = r_confs[:limit]    # SHQK : It is important to truncate the original conformer list as well to avoid list indexing error arising due to 1:1 matching in the M+N algorithm
+        r_confs = r_confs[:limit]    
         biased_p = biased_p[:limit]
     if len(p_confs) > limit:
-        p_confs = p_confs[:limit]    # SHQK : It is important to truncate the original conformer list as well to avoid list indexing error arising due to 1:1 matching in the M+N algorithm
+        p_confs = p_confs[:limit]    
         biased_r = biased_r[:limit]
 
 
-    # --- STEP C: Cross-Product Evaluation & Tournament ---
-    # SHQK : Replacing the M*N evaluation loop with a 1:1 (M+N) index-matching approach in the following. The previous M*N approach was not only an inefficient bottleneck, but also incorrectly implemented
+    # --- STEP B: Reactant-Product Pair Evaluation & Tournament ---
     approved_pairs = []
     approved_indicators = []
     dropped_pairs = 0
 
     for ind, r_c in enumerate(r_confs):
-#        for p_c in biased_p:
          
             # 1. Unaligned Evaluation
             ind_unaligned = return_indicator(E=r_c.elements, RG=r_c.geo, PG=biased_p[ind].geo)
@@ -103,14 +93,12 @@ def select_gsm_pairs(rxn, config):
                 approved_pairs.append({
                     "r_conf": r_c,
                     "p_conf": best_p,
-                    "score": best_prob[0][1]    # SHQK : Or best_prob[0][0]??. [0][1] is correct in this case, as later the pairs are stored in descending order (reverse=True).
+                    "score": best_prob[0][1]
                 })
-            else:   # SHQK : Debugging..... 
+            else:
                 dropped_pairs += 1
-
 ####################################################################
     for ind, p_c in enumerate(p_confs):
-#        for p_c in biased_p:
 
             # 1. Unaligned Evaluation
             ind_unaligned = return_indicator(E=r_c.elements, RG=p_c.geo, PG=biased_r[ind].geo)
@@ -139,10 +127,10 @@ def select_gsm_pairs(rxn, config):
                     "p_conf": p_c,
                     "score": best_prob[0][1]
                 })
-            else:    # SHQK : Debugging.....
+            else:
                 dropped_pairs += 1
 
-    # --- STEP D: Sort and Select Top N ---
+    # --- STEP C: Sort and Select Top N ---
     # Sort descending by probability of success
     approved_pairs.sort(key=lambda x: x["score"], reverse=True)
 

--- a/yarp/reaction/external/conf_gen.py
+++ b/yarp/reaction/external/conf_gen.py
@@ -122,7 +122,7 @@ class CrestConfCalculator(ConfTask):
 
     def cleanup(self):
         """Delete CREST intermediate files, keeping conformer data and logs."""
-        keep = {"crest_conformers.xyz", "crest.energies", "crest_run.log", self.xyz_file, "run_crest_cmd.sh"}
+        keep = {"crest_conformers.xyz", "cre_members", "crest.energies", "crest_run.log", self.xyz_file, "run_crest_cmd.sh"}    # SHQK : Keeping cre_members helps readily get the total number of generated conformers. Please keep it.
         for item in self.scratch_dir.iterdir():
             if item.name not in keep:
                 if item.is_file():


### PR DESCRIPTION
Main changes: Modified/Fixed the conformer selection logic in `yarp/reaction/conf_sampling/select_pairs.py`. Comments are mainly to track the changes made and to explain why the change was made. Once reviewed, they can be removed. 
Minor change: Keeping the cre_members in the CREST output folder to directly get the number of conformers generated (`yarp/reaction/external/conf_gen.py`)