### PR TITLE
Force field optimization fix

### DIFF
--- a/helper/read_pkl.py
+++ b/helper/read_pkl.py
@@ -155,7 +155,7 @@ def main(args):
         headers.insert(0, "Reaction Hash")
     for direction, _, label, key in columns:
         headers.append(f"{key} {direction} {label}")
-    if args.network_meta:
+    if args.meta:
         headers.append("network_meta_keys")
 
     data = []
@@ -169,7 +169,7 @@ def main(args):
 
         for _, attr, _, key in columns:
             row.append(_format_optional_value(_reaction_value(rxn, attr, key)))
-        if args.network_meta:
+        if args.meta:
             row.append(_network_meta_keys(rxn))
         data.append(row)
 

--- a/test/util/test_obabel.py
+++ b/test/util/test_obabel.py
@@ -4,23 +4,12 @@ import yarp as yp
 from yarp.reaction.enum import enumerate_products
 from yarp.yarpecule.graph.adjacency import table_generator
 
-from yarp.util.rdkit import yarpecule_to_rdmol, geom_from_rdmol, rdkit_ff_opt
-
-class TestGeom:
-    def test_preserved_geom(self):
-        fran_smi = '[c:0]12[c:1]([H:7])[c:2]([H:8])[c:3]([H:9])[c:4]([H:10])[c:5]1[C-:12]([O-:11])[N:13]([H:6])[S+2:14]2'
-        fran = yp.yarpecule(fran_smi)
-        mol = yarpecule_to_rdmol(fran.elements, fran.adj_mat, fran.bond_mats[0], fran._atom_info, fran.geo)
-
-        geo = geom_from_rdmol(mol)
-
-        diff = fran.geo - geo
-        assert np.all(diff == 0)
+from yarp.util.obabel import obabel_ff_opt
 
 class TestFFOpt:
     def test_haa_2_ring(self):
         """
-        RDkit correctly forms strained
+        Recording a bug in Open Babel for the formation of strained
         3 member ring product geometry when starting from HAA reactant geometry
         """
         reactant = yp.yarpecule('O=CCO')
@@ -28,16 +17,15 @@ class TestFFOpt:
         target_hash = "1034502.7961211"
         target_product = next(p for p in products if str(p.hash) == str(target_hash))
 
-        opt_geo = rdkit_ff_opt(target_product, lot='uff', maxiter=200)
+        opt_geo = obabel_ff_opt(target_product, lot='uff', maxiter=200)
         opt_adj = table_generator(elements=target_product.elements, geometry=opt_geo)
 
         diff = opt_adj - target_product.adj_mat
-        assert np.all(diff == 0)
+        assert not np.all(diff == 0)
 
     def test_3hp_2_acetaldehyde(self):
         """
-        Recording a bug:
-        RDKit fails to optimize product acetaldehyde + O2 from 3HP geom
+        Open Babel correctly optimizes product acetaldehyde + O2 from 3HP geom
         """
         reactant = yp.yarpecule('O=CCOO')
         products = enumerate_products(reactant, 2, 2, mode="concerted")
@@ -45,16 +33,15 @@ class TestFFOpt:
 
         target_product = next(p for p in products if str(p.hash) == str(target.hash))
 
-        opt_geo = rdkit_ff_opt(target_product, lot='uff', maxiter=200)
+        opt_geo = obabel_ff_opt(target_product, lot='uff', maxiter=200)
         opt_adj = table_generator(elements=target_product.elements, geometry=opt_geo)
 
         diff = opt_adj - target_product.adj_mat
-        assert not np.all(diff == 0)
+        assert np.all(diff == 0)
 
     def test_3hp_2_aldehyde(self):
         """
-        Recording a bug:
-        RDKit fails to correctly optimize product formaldehyde + ester from 3HP geom
+        Open Babel correctly optimizes product formaldehyde + ester from 3HP geom
         """
         reactant = yp.yarpecule('O=CCOO')
         products = enumerate_products(reactant, 2, 2, mode="concerted")
@@ -62,9 +49,8 @@ class TestFFOpt:
 
         target_product = next(p for p in products if str(p.hash) == str(target.hash))
 
-        opt_geo = rdkit_ff_opt(target_product, lot='uff', maxiter=200)
+        opt_geo = obabel_ff_opt(target_product, lot='uff', maxiter=200)
         opt_adj = table_generator(elements=target_product.elements, geometry=opt_geo)
 
         diff = opt_adj - target_product.adj_mat
-        assert not np.all(diff == 0)
-
+        assert np.all(diff == 0)

--- a/yarp/reaction/generate_rxns.py
+++ b/yarp/reaction/generate_rxns.py
@@ -1,11 +1,8 @@
 """
 Wrapper function to manage the generation of reaction objects during main_yarp routine
 """
-import os
-import fnmatch
 import pickle
 import numpy as np
-from openbabel import pybel
 from pathlib import Path
 
 from yarp.yarpecule.yarpecule import yarpecule
@@ -13,7 +10,9 @@ from yarp.yarpecule.input_parsers import load_reaction_from_xyz_file, load_react
 from yarp.reaction.reaction import reaction
 from yarp.reaction.enum import enumerate_products
 from yarp.reaction.filters import filter_enum_candidates, filter_enum_products
-from yarp.util.write_files import mol_write_yp
+from yarp.util.rdkit import rdkit_ff_opt
+from yarp.util.obabel import obabel_ff_opt
+from yarp.yarpecule.graph.adjacency import table_generator
 
 
 def generate_rxns(inp):
@@ -63,6 +62,10 @@ def generate_rxns(inp):
 
             for prod in clean_products:
                 prod = quick_geom_opt(prod)
+                if prod is None:
+                    if verbose:
+                        print(f"  + SKIPPED! Unable to form valid product ({prod.canon_smi}) geom from reactant ({mol.canon_smi}) geom")
+                    continue
                 r2p = reaction(reactant, prod)
                 output[r2p.hash] = r2p
 
@@ -127,6 +130,10 @@ def generate_rxns(inp):
 
                 for prod in clean_products:
                     prod = quick_geom_opt(prod)
+                    if prod is None:
+                        if verbose:
+                            print(f"  + SKIPPED! Unable to form valid product ({prod.canon_smi}) geom from reactant ({mol.canon_smi}) geom")
+                        continue
                     r2p = reaction(mol, prod)
                     p2r = reaction(mol, prod)
 
@@ -190,20 +197,28 @@ def quick_geom_opt(molecule, lot="uff"):
         optimized molecule
     '''
 
-    # Write yarpecule object to a temporary mol file
-    mol_file = '.tmp.mol'
-    mol_write_yp(mol_file, molecule.elements, molecule.geo,
-                 molecule.bond_mats[0], molecule.adj_mat)
+    # First, attempt to optimize with RDKit
+    rd_opt_g = rdkit_ff_opt(molecule, lot=lot)
 
-    # Use openbabel to perform geometry optimization
-    mol = next(pybel.readfile("mol", mol_file))
-    mol.localopt(forcefield=lot)
+    # Check if optimization preserved starting connectivity
+    rd_adj = table_generator(molecule.elements, rd_opt_g)
+    rd_diff = rd_adj - molecule.adj_mat
 
-    # Update yarpecule with optimized geometry coordinates
-    for count_i, i in enumerate(molecule.geo):
-        molecule.geo[count_i] = mol.atoms[count_i].coords
+    # If RDKit generated a garbage geom, try Open Babel
+    if not np.all(rd_diff == 0):
+        ob_opt_g = obabel_ff_opt(molecule, lot=lot)
 
-    # Delete temporary mol file
-    os.system("rm {}".format(mol_file))
+        # If Open Babel fails too, we return None
+        ob_adj = table_generator(molecule.elements, ob_opt_g)
+        ob_diff = ob_adj - molecule.adj_mat
+        if not np.all(ob_diff == 0):
+            return None
+        
+        # If all goes well, update geometry and return
+        molecule._geo = ob_opt_g
+        return molecule
 
-    return molecule
+    # Otherwise, if RDKit gave a valid geom, use that one
+    else:
+        molecule._geo = rd_opt_g
+        return molecule

--- a/yarp/util/obabel.py
+++ b/yarp/util/obabel.py
@@ -1,0 +1,42 @@
+import os
+import numpy as np
+from openbabel import pybel
+
+from yarp.util.write_files import mol_write_yp
+
+def obabel_ff_opt(molecule, lot="uff", maxiter=500):
+    '''
+    Perform low-level level geometry optimization on yarpecule using openbabel.
+
+    Parameters:
+    ----------
+    molecule : yarpecule object
+        molecule to be optimized 
+
+    lot : string
+        Level of theory used for quick optimization
+
+    Returns
+    -------
+    opt_geom : nd array (N x 3)
+        optimized geometry
+    '''
+
+    # Write yarpecule object to a temporary mol file
+    mol_file = '.tmp.mol'
+    mol_write_yp(mol_file, molecule.elements, molecule.geo,
+                 molecule.bond_mats[0], molecule.adj_mat)
+
+    # Use openbabel to perform geometry optimization
+    mol = next(pybel.readfile("mol", mol_file))
+    mol.localopt(forcefield=lot, steps=maxiter)
+
+    # Delete temporary mol file
+    os.system("rm {}".format(mol_file))
+
+    # Collect optimized geometry coordinates
+    opt_geom = np.zeros_like(molecule.geo)
+    for count_i, i in enumerate(opt_geom):
+        opt_geom[count_i] = mol.atoms[count_i].coords
+
+    return opt_geom

--- a/yarp/util/obabel.py
+++ b/yarp/util/obabel.py
@@ -8,7 +8,7 @@ def obabel_ff_opt(molecule, lot="uff", maxiter=500):
     '''
     Perform low-level level geometry optimization on yarpecule using openbabel.
 
-    Parameters:
+    Parameters
     ----------
     molecule : yarpecule object
         molecule to be optimized 
@@ -16,10 +16,21 @@ def obabel_ff_opt(molecule, lot="uff", maxiter=500):
     lot : string
         Level of theory used for quick optimization
 
+    maxiter : int
+        Maximum number of optimization steps
+        
+
     Returns
     -------
     opt_geom : nd array (N x 3)
         optimized geometry
+
+    Notes
+    -----
+    Supported force fields (`lot`):
+        - 'uff' : Universal Force Field, general-purpose, works for most elements
+        - 'mmff94' : Merck Molecular Force Field, better for organics
+        - 'ghemical' : simpler/faster, less accurate
     '''
 
     # Write yarpecule object to a temporary mol file

--- a/yarp/util/rdkit.py
+++ b/yarp/util/rdkit.py
@@ -2,6 +2,7 @@
 Helper functions for integration with RDKit
 """
 from rdkit import Chem
+from rdkit.Chem import AllChem
 from rdkit.Chem import rdchem
 from rdkit.Geometry import Point3D
 import numpy as np
@@ -164,3 +165,36 @@ def geom_from_rdmol(mol, conf_index=0):
             geo[idx] = [pos.x, pos.y, pos.z]
 
     return geo
+
+def rdkit_ff_opt(ypcule, lot='uff', maxiter=200):
+    '''
+    Perform low-level level geometry optimization of yarpecule geometry
+    via RDKit mol object.
+
+    Parameters:
+    ----------
+    ypcule : yarpecule object
+        molecule to be optimized
+
+    lot : string
+        Level of theory used for quick optimization
+        ERM: mmff94 has a tendency to reform the reactant geometry
+        when used to generate initial geom of products post product enumeration
+
+    Returns:
+    --------
+    opt_geom : nd array (N x 3)
+        optimized geometry
+    '''
+
+    rdmol = yarpecule_to_rdmol(elements=ypcule.elements, adj=ypcule.adj_mat, bond_orders=ypcule.bond_mats[0],
+                               atom_info=ypcule._atom_info, geo=ypcule.geo)
+
+    if lot == "uff":
+        opt = AllChem.UFFOptimizeMolecule(rdmol, maxIters=maxiter, ignoreInterfragInteractions=False)
+    elif lot == "mmff94":
+        opt = AllChem.MMFFOptimizeMolecule(rdmol, maxIters=maxiter, ignoreInterfragInteractions=False)
+
+    opt_geom = geom_from_rdmol(rdmol)
+
+    return opt_geom

--- a/yarp/util/rdkit.py
+++ b/yarp/util/rdkit.py
@@ -181,6 +181,9 @@ def rdkit_ff_opt(ypcule, lot='uff', maxiter=200):
         ERM: mmff94 has a tendency to reform the reactant geometry
         when used to generate initial geom of products post product enumeration
 
+    maxiter : int
+        Maximum number of optimization steps
+    
     Returns:
     --------
     opt_geom : nd array (N x 3)

--- a/yarp/yarpecule/yarpecule.py
+++ b/yarp/yarpecule/yarpecule.py
@@ -479,7 +479,6 @@ class yarpecule:
         # This should raise an error if code is modifying the
         # class attributes (which it should NOT be doing here!!!)
         E = self.elements
-        G = self.geo
         bond_mat = self.bond_mats[0]
         adj_mat = self.adj_mat
 
@@ -496,34 +495,25 @@ class yarpecule:
                 groups += [new_group]
         inchikey = []
 
-        # Generate a temporary mol file for each separated graph
-        # Then use it to get an INCHI key
-        tmp_file = ".tmp.mol"
+        # Generate INCHI key for each separated graph
         for group in groups:
             # extract subgroup information
-            N_atom = len(group)
-            geo = np.zeros([N_atom, 3])
-            for count_i, i in enumerate(group):
-                geo[count_i, :] = G[i, :]
             elements = [E[ind] for ind in group]
             bem = [bond_mat[group][:, group]]
             adj = adj_mat[group][:, group]
-            
-            # generate mol file and read in to Open Babel
-            mol_write_yp(tmp_file, elements, geo, bem[0], adj)
-            mol = next(pybel.readfile("mol", tmp_file))
-            
+
+            # generate RDKit mol object from subgroup
+            mol = yarpecule_to_rdmol(elements=elements, adj=adj, bond_orders=bem[0])
+
             try:
-                inchi = mol.write(format='inchikey').strip().split()[0]
+                inchi = Chem.inchi.MolToInchiKey(mol).strip().split()[0]
             except:
                 if verbose:
                     print("WARNING: ERROR in INCHI key generation!")
-                    print(f"  --> {mol.write(format='inchikey')}")
+                    print(f"  --> {Chem.inchi.MolToInchiKey(mol)}")
                 continue
-            
+
             inchikey += [inchi]
-            
-            os.remove(tmp_file)
 
         if len(inchikey) == 0:
             self._inchi = "ERROR"


### PR DESCRIPTION
Taking advantage of the more robust RDKit mol object builder from PR #36 , I clean up the generation of INCHI keys (`yarp/yarpecule/yarpecule.py` -> `self.get_inchi()`) and attempt to make a quick fix for issue #31 

Overview of changes:
- [x] Generate INCHI keys via RDKit mol object. This avoids the need to write a temporary MOL file to disk. Turns out, also, you don't need the geometry in order to generate the INCHI key, at least not the first 14 characters, which is all that we care about
- [x] Quick bug fix in the `helper/read_pkl.py` script (pretty sure I broke this in PR #29 )
- [x] Added FF opt functions for both RDKit and Open Babel in `yarp/util/` folder
- [x] Updated the `quick_geom_opt()` function in `yarp/reaction/generate_rxns.py` to first attempt to form the product geometry using RDKit, then fall back to Open Babel if RDKit changes the connectivity of the product. If neither RDKit nor Open Babel can form a valid product with UFF, we throw the reaction out (verbose messages should trigger)
- [x] Added testing cases for 3 molecules, two of which fail for RDKit/pass for Open Babel FF optimizations, and one which fails for Open Babel/passes for RDKit.