### PR TITLE
Product blinders and other quick bug patches

### DIFF
--- a/yarp/network/network.py
+++ b/yarp/network/network.py
@@ -3,6 +3,7 @@ Definition of the network object class.
 """
 
 import networkx as nx
+import numpy as np
 from copy import deepcopy
 from typing import Iterable, Dict, Any, Optional
 
@@ -16,7 +17,7 @@ class network:
     def __init__(self, rxns, dG_lot=None):
         self.rxns = self._normalize_rxn_dict(rxns)
 
-        considered_rxns = self._get_rxns_by_metadata(rxns.values(), key="prod_blind_selected", value=True)
+        considered_rxns = self._get_rxns_by_metadata(self.rxns.values(), key="prod_blind_selected", value=True)
         self.n_considered_rxns = len(considered_rxns)
 
         self.crn = self._gen_s2r_bipartite_graph(self.rxns, barrier_lot=dG_lot)
@@ -64,6 +65,20 @@ class network:
                 out[r.hash] = r
         return out
 
+    def _species_label(self, y):
+        """Provenance-independent species node label.
+
+        yarpecule.hash sums over all resonance BEMs, and the number of BEMs
+        lewis_struct() finds depends on atom ordering -- so the same molecule
+        hashes differently as an enumerated product vs. a canon-ordered reactant.
+        Hash the single best-scoring BEM instead.
+        """
+        scores = np.asarray(y.bond_mat_scores)
+        best = min(np.flatnonzero(np.isclose(scores, scores.min())),
+                key=lambda i: np.sum(y.bond_mats[i] * np.outer(y.atom_hashes, y.atom_hashes)))
+        bem = y.bond_mats[best]
+        return f"Sp_{float(np.round(np.sum(bem * np.outer(y.atom_hashes, y.atom_hashes)), 7))}"
+
     def _gen_s2r_bipartite_graph(self, yp_rxns, barrier_lot=None):
         """
         Convert input reactions into NetworkX DiGraph (directed graph) object
@@ -76,12 +91,12 @@ class network:
             crn.add_node(rxn_label, type='reaction')
 
             for r in rxn.reactant.species:
-                reactant_label = f'Sp_{r.hash}'
+                reactant_label = self._species_label(r)
                 crn.add_node(reactant_label, type='species', smi=r.canon_smi)
                 crn.add_edge(reactant_label, rxn_label, dG=rxn.barrier.get(barrier_lot, 1000.0), weiner=1)
 
             for p in rxn.product.species:
-                product_label = f'Sp_{p.hash}'
+                product_label = self._species_label(p)
                 crn.add_node(product_label, type='species', smi=p.canon_smi)
                 crn.add_edge(rxn_label, product_label, dG=0, weiner=0)
 
@@ -109,8 +124,8 @@ class network:
         if len(start.separate()) > 1 or len(end.separate()) > 1:
             raise RuntimeError("Requested start and end nodes must be single molecules")
 
-        start_label = f'Sp_{start.hash}'
-        end_label = f'Sp_{end.hash}'
+        start_label = self._species_label(start)
+        end_label = self._species_label(end)
 
         path = nx.shortest_path(G=self.crn, source=start_label, target=end_label)
 
@@ -237,8 +252,8 @@ class network:
         if verbose:
             print(f"Getting all simple paths from {start.canon_smi} to {end.canon_smi}...")
 
-        start_label = f'Sp_{start.hash}'
-        end_label = f'Sp_{end.hash}'
+        start_label = self._species_label(start)
+        end_label = self._species_label(end)
         paths = list(nx.all_simple_paths(self.crn, start_label, end_label, cutoff=cutoff))
 
         rxn_paths = []
@@ -338,8 +353,8 @@ class network:
         if len(start.separate()) > 1 or len(end.separate()) > 1:
             raise RuntimeError("Requested start and end nodes must be single molecules")
 
-        start_label = f'Sp_{start.hash}'
-        end_label = f'Sp_{end.hash}'
+        start_label = self._species_label(start)
+        end_label = self._species_label(end)
         path = nx.dijkstra_path(self.crn, start_label, end_label, weight=objective)
 
         rxn_steps = path[1::2]  # Extract reaction labels from path

--- a/yarp/network/network.py
+++ b/yarp/network/network.py
@@ -78,7 +78,7 @@ class network:
             for r in rxn.reactant.species:
                 reactant_label = f'Sp_{r.hash}'
                 crn.add_node(reactant_label, type='species', smi=r.canon_smi)
-                crn.add_edge(reactant_label, rxn_label, dG=rxn.barrier.get(barrier_lot, -1000), weiner=1)
+                crn.add_edge(reactant_label, rxn_label, dG=rxn.barrier.get(barrier_lot, 1000.0), weiner=1)
 
             for p in rxn.product.species:
                 product_label = f'Sp_{p.hash}'

--- a/yarp/reaction/enum.py
+++ b/yarp/reaction/enum.py
@@ -563,7 +563,7 @@ def break_bonds(yarpecules,n=1,react=[],hashes=None,break_higher_order=False,rem
                     yield tmp
 
 
-def bnfn(yarpecules, n, react=[], hashes=None, hash_filter=True, lower_score=True, keep_symmetric=True, verbose=True, debug=False):
+def bnfn(yarpecules, n, react=[], hashes=None, hash_filter=False, lower_score=True, keep_symmetric=True, verbose=True, debug=False):
     """
     This function provides a shortcut for enumerating "break n form n" products without generating intermediate 
     zwitterionic/dangling bond species

--- a/yarp/reaction/generate_rxns.py
+++ b/yarp/reaction/generate_rxns.py
@@ -215,8 +215,8 @@ def quick_geom_opt(molecule, lot="uff"):
         # If Open Babel fails too, we return None
         ob_adj = table_generator(molecule.elements, ob_opt_g)
         ob_diff = ob_adj - molecule.adj_mat
-        if not np.all(ob_diff == 0):
-            return None
+        # if not np.all(ob_diff == 0):
+        #     return None
         
         # If all goes well, update geometry and return
         molecule._geo = ob_opt_g

--- a/yarp/util/obabel.py
+++ b/yarp/util/obabel.py
@@ -4,7 +4,7 @@ from openbabel import pybel
 
 from yarp.util.write_files import mol_write_yp
 
-def obabel_ff_opt(molecule, lot="uff", maxiter=500):
+def obabel_ff_opt(molecule, lot="uff", maxiter=3000):
     '''
     Perform low-level level geometry optimization on yarpecule using openbabel.
 

--- a/yarp/util/rdkit.py
+++ b/yarp/util/rdkit.py
@@ -231,7 +231,7 @@ def geom_from_rdmol(mol, conf_index=0):
 
     return geo
 
-def rdkit_ff_opt(ypcule, lot='uff', maxiter=200):
+def rdkit_ff_opt(ypcule, lot='uff', maxiter=3000):
     '''
     Perform low-level level geometry optimization of yarpecule geometry
     via RDKit mol object.

--- a/yarp/yarpecule/distance_metrics.py
+++ b/yarp/yarpecule/distance_metrics.py
@@ -8,7 +8,6 @@ Distance metrics implemented:
     * crippen_diff
     * delta_tpsa
     * approx_dipole_magnitude
-    * maccs_tanimoto_distance
     * mcs_bond_edit_distance
     * am_ged
     * cost_aware_ged
@@ -47,6 +46,7 @@ def compute_min_distance(mol_yp, target_smi, metric='soergel'):
 
     return min(all_dist)
 
+
 def compute_distance(smi1, smi2, metric='soergel'):
     """
     Compute distance between two SMILES based on requested metric.
@@ -61,8 +61,6 @@ def compute_distance(smi1, smi2, metric='soergel'):
         dist = delta_tpsa(smi1, smi2)
     elif metric == 'approx_dipole_magnitude':
         dist = approx_dipole_magnitude(smi1, smi2)
-    elif metric == 'maccs_tanimoto_distance':
-        dist = maccs_tanimoto_distance(smi1, smi2)
     elif metric == 'mcs_bond_edit_distance':
         dist = mcs_bond_edit_distance(smi1, smi2)
     elif metric == 'am_ged':
@@ -74,10 +72,12 @@ def compute_distance(smi1, smi2, metric='soergel'):
 
     return dist
 
+
 def soergel(smi1, smi2):
     try:
-        mol1 = Chem.MolFromSmiles(smi1)
-        mol2 = Chem.MolFromSmiles(smi2)
+        mol1 = Chem.AddHs(Chem.MolFromSmiles(smi1))
+        mol2 = Chem.AddHs(Chem.MolFromSmiles(smi2))
+        if mol1 is None or mol2 is None: return np.nan
 
         # Create a Morgan fingerprint generator (radius 2, 2048 bits)
         generator = GetMorganGenerator(
@@ -97,81 +97,90 @@ def soergel(smi1, smi2):
     except Exception as e:
         return np.nan
 
+
 def delta_bertz(smi_1,smi_2):
-    """Absolute difference in RDKit Bertz topological complexity."""
+    """Absolute difference in Bertz topological complexity."""
     try:
-        m1, m2 = Chem.MolFromSmiles(smi_1), Chem.MolFromSmiles(smi_2)
-        if m1 is None or m2 is None:
-            return None
+        m1, m2 = Chem.AddHs(Chem.MolFromSmiles(smi_1)), Chem.AddHs(Chem.MolFromSmiles(smi_2))
+        if m1 is None or m2 is None: return np.nan
         v1 = float(GraphDescriptors.BertzCT(m1))
         v2 = float(GraphDescriptors.BertzCT(m2))
         return abs(v1 - v2)
     except Exception as e:
         return np.nan
-    
+
+
 def crippen_diff(smi1, smi2):
-    """Absolute difference in Crippen logP."""
+    """Absolute difference in Crippen molar refractivity."""
     try:
-        m1, m2 = Chem.MolFromSmiles(smi1), Chem.MolFromSmiles(smi2)
-        if m1 is None or m2 is None: return None
+        m1, m2 = Chem.AddHs(Chem.MolFromSmiles(smi1)), Chem.AddHs(Chem.MolFromSmiles(smi2))
+        if m1 is None or m2 is None: return np.nan
         v1 = Crippen.MolMR(m1)
         v2 = Crippen.MolMR(m2)
         return float(abs(v1 - v2))
     except Exception as e:
         return np.nan
-    
+
+
 def delta_tpsa(smi_1: str, smi_2: str):
-    """Absolute difference in Topological Polar Surface Area (TPSA)."""
+    """Absolute difference in approximated Topological Polar Surface Area (TPSA)."""
     try:
-        m1, m2 = Chem.MolFromSmiles(smi_1), Chem.MolFromSmiles(smi_2)
-        if m1 is None or m2 is None: return None
+        m1, m2 = Chem.AddHs(Chem.MolFromSmiles(smi_1)), Chem.AddHs(Chem.MolFromSmiles(smi_2))
+        if m1 is None or m2 is None: return np.nan
         v1 = rdMolDescriptors.CalcTPSA(m1)
         v2 = rdMolDescriptors.CalcTPSA(m2)
         return float(abs(v1 - v2))
     except Exception as e:
         return np.nan
 
+
 def approx_dipole_magnitude(smi_1, smi_2):
-    """Approximate dipole moment magnitude difference using Gasteiger charges."""
+    """
+    Approximate dipole moment magnitude difference using Gasteiger charges.
+    ERM: May not work properly for charged species!
+    Also, unsure if units are in true Debye, but since we just want a difference,
+    this shouldn't qualitatively matter.
+    """
     try:
         m_1 = Chem.AddHs(Chem.MolFromSmiles(smi_1))
         m_2 = Chem.AddHs(Chem.MolFromSmiles(smi_2))
+        if m_1 is None or m_2 is None: return np.nan
+
+        # Generate random conformer and optimize with MMFF94
         AllChem.EmbedMolecule(m_1, randomSeed=42)
         AllChem.EmbedMolecule(m_2, randomSeed=42)
+        AllChem.MMFFOptimizeMolecule(m_1)
+        AllChem.MMFFOptimizeMolecule(m_2)
+
+        # Compute atomic charges
         Chem.rdPartialCharges.ComputeGasteigerCharges(m_1)
         Chem.rdPartialCharges.ComputeGasteigerCharges(m_2)
+
+        # Assemble total dipole moment vectors
         coords_1 = m_1.GetConformer().GetPositions()
         coords_2 = m_2.GetConformer().GetPositions()
         charges_1 = np.array([float(a.GetProp('_GasteigerCharge')) for a in m_1.GetAtoms()])
         charges_2 = np.array([float(a.GetProp('_GasteigerCharge')) for a in m_2.GetAtoms()])
         dip_1 = np.sum(coords_1 * charges_1[:, None], axis=0)
         dip_2 = np.sum(coords_2 * charges_2[:, None], axis=0)
+
+        # Return difference in dipole momemnt magnitudes
         return abs(np.linalg.norm(dip_1) - np.linalg.norm(dip_2))
     except:
         return np.nan
-    
-def maccs_tanimoto_distance(smi_1, smi_2):
-    """MACCS Tanimoto distance."""
-    try:
-        m1, m2 = Chem.MolFromSmiles(smi_1), Chem.MolFromSmiles(smi_2)
-        if m1 is None or m2 is None: return None
-        fp1 = MACCSkeys.GenMACCSKeys(m1)
-        fp2 = MACCSkeys.GenMACCSKeys(m2)
-        sim = DataStructs.TanimotoSimilarity(fp1, fp2)
-        return float(1.0 - sim)
-    except Exception as e:
-        return np.nan
-    
+
+
 def mcs_bond_edit_distance(smi_1, smi_2, timeout=10):
     """MCS-based bond edit distance."""
     try:
-        m1, m2 = Chem.MolFromSmiles(smi_1), Chem.MolFromSmiles(smi_2)
+        m1, m2 = Chem.AddHs(Chem.MolFromSmiles(smi_1)), Chem.AddHs(Chem.MolFromSmiles(smi_2))
         if m1 is None or m2 is None: return None
         b1, b2 = m1.GetNumBonds(), m2.GetNumBonds()
         if (b1 + b2) == 0:
             return 0.0  # both have no bonds; treat as identical
         params = rdFMCS.MCSParameters()
         params.MaximizeBonds = True
+        # ERM: These appear to not be implemented in RDKit v2025.09.5
         # params.CompleteRingsOnly = completeRingsOnly
         # params.RingMatchesRingOnly = ringMatchesRingOnly
         params.Timeout = timeout
@@ -184,9 +193,18 @@ def mcs_bond_edit_distance(smi_1, smi_2, timeout=10):
         return float(dist)
     except Exception as e:
         return np.nan
-    
+
+
 def atom_map_ged(smi_1, smi_2):
-    """Unweighted graph edit distance between two atom-mapped SMILES strings."""
+    """
+    Unweighted graph edit distance between two atom-mapped SMILES strings.
+    ERM: This is not a reliable distance metric to use unless you've got a
+    correct target atom-map. Also, this doesn't consider bond order changes
+    at all, i.e. pi-bond breakage are not reflected here.
+    One reason for this is the issue of aromaticity, and different Kekulizations
+    appearing as non-zero GED values without proper accounting of things.
+    Also... not sure why we're throwing away elements involving hydrogen...
+    """
     try:
         adj_mat_1, _, atom_info_1 = smiles2adjmat(smi_1)
         adj_mat_2, _, atom_info_2 = smiles2adjmat(smi_2)
@@ -247,8 +265,8 @@ def cost_aware_ged(smi_1, smi_2):
     changes, and bond creation/destruction.
     """
     try:
-        mol_1 = Chem.MolFromSmiles(smi_1)
-        mol_2 = Chem.MolFromSmiles(smi_2)
+        mol_1 = Chem.AddHs(Chem.MolFromSmiles(smi_1))
+        mol_2 = Chem.AddHs(Chem.MolFromSmiles(smi_2))
         if mol_1 is None or mol_2 is None:
             return None
 

--- a/yarp/yarpecule/distance_metrics.py
+++ b/yarp/yarpecule/distance_metrics.py
@@ -231,7 +231,7 @@ def atom_map_ged(smi_1, smi_2):
         return np.nan
 
 
-def cost_aware_ged(smi_1, smi_2):
+def cost_aware_ged(smi_1, smi_2, upper_bound=12.0):
     """
     Cost-aware graph edit distance between two SMILES strings.
 
@@ -291,6 +291,7 @@ def cost_aware_ged(smi_1, smi_2):
             edge_subst_cost=lambda bond1, bond2: 0.0 if bond1["bond_order"] == bond2["bond_order"] else 0.7,
             edge_del_cost=lambda bond: 0.7,
             edge_ins_cost=lambda bond: 0.7,
+            upper_bound=upper_bound,
         ))
     except Exception:
         return np.nan

--- a/yarp/yarpecule/distance_metrics.py
+++ b/yarp/yarpecule/distance_metrics.py
@@ -15,7 +15,7 @@ Distance metrics implemented:
 from rdkit import Chem
 from rdkit.Chem.rdFingerprintGenerator import GetMorganGenerator
 from rdkit.DataStructs.cDataStructs import TanimotoSimilarity
-from rdkit.Chem import AllChem, GraphDescriptors, Crippen, rdMolDescriptors, MACCSkeys, DataStructs, rdFMCS
+from rdkit.Chem import AllChem, GraphDescriptors, Crippen, rdMolDescriptors, rdFMCS
 import networkx as nx
 import numpy as np
 
@@ -174,7 +174,7 @@ def mcs_bond_edit_distance(smi_1, smi_2, timeout=10):
     """MCS-based bond edit distance."""
     try:
         m1, m2 = Chem.AddHs(Chem.MolFromSmiles(smi_1)), Chem.AddHs(Chem.MolFromSmiles(smi_2))
-        if m1 is None or m2 is None: return None
+        if m1 is None or m2 is None: return np.nan
         b1, b2 = m1.GetNumBonds(), m2.GetNumBonds()
         if (b1 + b2) == 0:
             return 0.0  # both have no bonds; treat as identical
@@ -209,7 +209,7 @@ def atom_map_ged(smi_1, smi_2):
         adj_mat_1, _, atom_info_1 = smiles2adjmat(smi_1)
         adj_mat_2, _, atom_info_2 = smiles2adjmat(smi_2)
         if adj_mat_1 is None or adj_mat_2 is None:
-            return None
+            return np.nan
 
         keep_1 = [i for i in range(len(atom_info_1)) if atom_info_1[i]["element"] != "h"]
         keep_2 = [i for i in range(len(atom_info_2)) if atom_info_2[i]["element"] != "h"]
@@ -268,7 +268,7 @@ def cost_aware_ged(smi_1, smi_2):
         mol_1 = Chem.AddHs(Chem.MolFromSmiles(smi_1))
         mol_2 = Chem.AddHs(Chem.MolFromSmiles(smi_2))
         if mol_1 is None or mol_2 is None:
-            return None
+            return np.nan
 
         graph_1 = nx.Graph()
         for atom in mol_1.GetAtoms():


### PR DESCRIPTION
This is a bit of a hodgepodge collection of YARP code adjustments I've needed to make as part of data generation for an upcoming manuscript.

Not sure how many (if any) of these changes should actually be merged into the `master` branch...

Overview of changes made so far:
- [x] Various fixes to the chemical distance metrics (include hydrogens, debug MCS bond edit distance, upper bound to CA-GED distance)
- [x] Change default reaction barrier to +1000 kcal/mol, instead of -1000 kcal/mol for reactions without barriers when building out network class' bipartite graph
- [x] Turn off "bad geometry throwaway" filter after product enumeration; geometries are still going to be bad, but I'm just working with EGAT barrier prediction so it doesn't matter right now
- [x] Turn off `hash_filter` in `bfnf` default, so that all R -> P mappings are returned

Open issues to resolve:
- [ ] Cost aware GED is prohibitively slow, even with the upper bound implemented. Need to revisit this, and adjust accordingly
