### PR TITLE
Add keep_job_logs option and gate cleanup behind it

### DIFF
--- a/yarp/reaction/external/calc_base.py
+++ b/yarp/reaction/external/calc_base.py
@@ -3,10 +3,12 @@ from pathlib import Path
 import shutil
 import subprocess
 
+
 class AsyncYarpCalculator:
     """
     Base class defining the asynchronous lifecycle interface required by progress_yarp.py.
     """
+
     def __init__(self, task_def, rxn_data, job_config):
         self.task_def = task_def
         self.config = task_def.config
@@ -23,7 +25,14 @@ class AsyncYarpCalculator:
         self.scratch_dir = path
         self.scratch_dir.mkdir(parents=True, exist_ok=True)
 
-    def get_container_prefix(self, image_name: str, work_dir: str, *, apptainer_run: bool = False, env_vars: dict = None) -> str:
+    def get_container_prefix(
+        self,
+        image_name: str,
+        work_dir: str,
+        *,
+        apptainer_run: bool = False,
+        env_vars: dict = None,
+    ) -> str:
         """
         The universal toggle for container execution.
         Maps the scratch directory to /work inside the container.
@@ -40,19 +49,22 @@ class AsyncYarpCalculator:
             # Use `docker images -q` rather than `docker image inspect` because
             # the latter fails silently with the containerd image store in Docker Desktop.
             check_cmd = subprocess.run(
-                ["docker", "images", "-q", image_name],
-                capture_output=True, text=True
+                ["docker", "images", "-q", image_name], capture_output=True, text=True
             )
 
             # 2. If output is empty, the image isn't local. Pull it!
             if not check_cmd.stdout.strip():
-                print(f"Docker image '{image_name}' not found locally. Pulling from registry...")
+                print(
+                    f"Docker image '{image_name}' not found locally. Pulling from registry..."
+                )
                 subprocess.run(["docker", "pull", image_name], check=True)
 
             env_flags = ""
             if env_vars:
                 env_flags = " ".join(f"-e {k}={v}" for k, v in env_vars.items()) + " "
-            return f"docker run --rm {env_flags} -v {work_dir}:/work -w /work {image_name}"
+            return (
+                f"docker run --rm {env_flags} -v {work_dir}:/work -w /work {image_name}"
+            )
 
         elif self.job_manager.container == "apptainer":
             # Sanitize the image name so it works as a safe, flat filename
@@ -77,7 +89,9 @@ class AsyncYarpCalculator:
                         f"  apptainer build {sif_path} /path/to/orca_6.0.1.def\n"
                         "Place the ORCA installer tarball next to the .def as documented in that file."
                     )
-                print(f"Apptainer image not found at {sif_path}. Pulling from Docker Hub...")
+                print(
+                    f"Apptainer image not found at {sif_path}. Pulling from Docker Hub..."
+                )
                 # Ensure the target directory actually exists before pulling
                 sif_path.parent.mkdir(parents=True, exist_ok=True)
                 # 2. Pull the docker image and convert it to a .sif file
@@ -103,7 +117,9 @@ class AsyncYarpCalculator:
 
             env_flags = ""
             if env_vars:
-                env_flags = " ".join(f"--env {k}={v}" for k, v in env_vars.items()) + " "
+                env_flags = (
+                    " ".join(f"--env {k}={v}" for k, v in env_vars.items()) + " "
+                )
             verb = "run" if apptainer_run else "exec"
             return f"apptainer {verb} -e {env_flags} --bind {work_dir}:/work --pwd /work {sif_path}"
 
@@ -130,7 +146,9 @@ class AsyncYarpCalculator:
                         f"  singularity build {sif_path} /path/to/orca_6.0.1.def\n"
                         "Place the ORCA installer tarball next to the .def as documented in that file."
                     )
-                print(f"Singularity image not found at {sif_path}. Pulling from Docker Hub...")
+                print(
+                    f"Singularity image not found at {sif_path}. Pulling from Docker Hub..."
+                )
                 # Ensure the target directory actually exists before pulling
                 sif_path.parent.mkdir(parents=True, exist_ok=True)
                 # 2. Pull the docker image and convert it to a .sif file
@@ -141,12 +159,16 @@ class AsyncYarpCalculator:
 
             env_flags = ""
             if env_vars:
-                env_flags = " ".join(f"--env {k}={v}" for k, v in env_vars.items()) + " "
+                env_flags = (
+                    " ".join(f"--env {k}={v}" for k, v in env_vars.items()) + " "
+                )
             verb = "run" if apptainer_run else "exec"
             return f"singularity {verb} -e {env_flags} --bind {work_dir}:/work --pwd /work {sif_path}"
 
         else:
-            raise ValueError(f"Unsupported container runner: {self.job_manager.container}")
+            raise ValueError(
+                f"Unsupported container runner: {self.job_manager.container}"
+            )
 
     def write_scheduler_headers(self, f):
         """Writes the top portion of the bash script based on scheduler type."""
@@ -162,13 +184,18 @@ class AsyncYarpCalculator:
                 f.write(f"#SBATCH -A {self.job_manager.account}\n")
             f.write(f"#SBATCH --job-name={job_name}\n")
             f.write(f"#SBATCH --partition={queue}\n")
-            f.write("#SBATCH -N 1\n") # nodes
-            f.write("#SBATCH -n 1\n") # tasks
+            f.write("#SBATCH -N 1\n")  # nodes
+            f.write("#SBATCH -n 1\n")  # tasks
             f.write(f"#SBATCH --cpus-per-task={cpus}\n")
             f.write(f"#SBATCH --mem-per-cpu={mem}M\n")
             f.write(f"#SBATCH --time={time}\n")
-            f.write("#SBATCH --output /dev/null\n")
-            f.write("#SBATCH --error /dev/null\n\n")
+
+            if self.job_manager.keep_job_logs:
+                f.write(f"#SBATCH --output {self.scratch_dir}/slurm-%j.out\n")
+                f.write(f"#SBATCH --error {self.scratch_dir}/slurm-%j.err\n\n")
+            else:
+                f.write("#SBATCH --output /dev/null\n")
+                f.write("#SBATCH --error /dev/null\n\n")
 
             if self.job_manager.module_container:
                 f.write(f"{self.job_manager.module_container}\n\n")
@@ -176,7 +203,7 @@ class AsyncYarpCalculator:
         elif scheduler == "sge":
             f.write(f"#$ -N {job_name}\n")
             f.write(f"#$ -q {queue}\n")
-            f.write(f"#$ -pe smp {cpus}\n") # ERM: this might be specific to CRC at ND
+            f.write(f"#$ -pe smp {cpus}\n")  # ERM: this might be specific to CRC at ND
             f.write(f"#$ -l h_vmem={mem * cpus}M\n")
             f.write(f"#$ -l h_rt={time}\n")
             f.write("#$ -o /dev/null\n")
@@ -209,8 +236,13 @@ class AsyncYarpCalculator:
         raise NotImplementedError
 
     def cleanup(self):
+        """Entry point for cleanup. Skips deletion entirely when keeping job logs."""
+        if self.job_manager.keep_job_logs:
+            return
+        self._do_cleanup()
+
+    def _do_cleanup(self):
         """5. Clean up large unneeded files, but keep logs if necessary."""
         # Default behavior: nuke the whole folder
         if self.scratch_dir and self.scratch_dir.exists():
             shutil.rmtree(self.scratch_dir)
-

--- a/yarp/reaction/external/conf_gen.py
+++ b/yarp/reaction/external/conf_gen.py
@@ -127,7 +127,7 @@ class CrestConfCalculator(ConfTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Delete CREST intermediate files, keeping conformer data and logs."""
         keep = {"crest_conformers.xyz", "cre_members", "crest.energies", "crest_run.log", self.xyz_file, "run_crest_cmd.sh"}    # SHQK : Keeping cre_members helps readily get the total number of generated conformers. Please keep it.
         for item in self.scratch_dir.iterdir():

--- a/yarp/reaction/external/irc_val.py
+++ b/yarp/reaction/external/irc_val.py
@@ -308,7 +308,7 @@ class PysisyphusIRCValCalculator(IRCValTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Per run dir: keep yaml input, log, and IRC endpoint geometries; delete input TS xyz and xTB calc dirs."""
         num_runs = self._get_num_runs()
         for i in range(1, num_runs + 1):
@@ -542,7 +542,7 @@ class OrcaIRCValCalculator(IRCValTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Per run dir: keep inp, output log, and IRC endpoint geometries; delete input TS xyz, .gbw, .densities, etc."""
         num_runs = self._get_num_runs()
         for i in range(1, num_runs + 1):

--- a/yarp/reaction/external/min_opt.py
+++ b/yarp/reaction/external/min_opt.py
@@ -146,7 +146,7 @@ class PysisyphusMinOptCalculator(MinOptTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         # Keep input, log, and final geometry; delete Hessian (scraped) and xTB calc dirs
         keep = {"min_opt.yaml", "min_opt.log", "final_geometry.xyz", "initial_geom.xyz", "run_pysis_rpopt.sh"}
         for item in self.scratch_dir.iterdir():
@@ -312,7 +312,7 @@ class OrcaMinOptCalculator(MinOptTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         # Keep input, log, and final geometry; delete Hessian (scraped), .gbw, .densities, etc.
         keep = {"min_opt.inp", "min_opt.out", "min_opt.xyz", "initial_geom.xyz", "run_orca_rpopt.sh"}
         for item in self.scratch_dir.iterdir():

--- a/yarp/reaction/external/ml_predict.py
+++ b/yarp/reaction/external/ml_predict.py
@@ -177,7 +177,7 @@ class EgatMLPredict(MLPredictTask):
                     rxn = self.reactions[rxn_hash]
                     rxn.heat_of_rxn[self.config.model] = enthalpy
 
-    def cleanup(self):
+    def _do_cleanup(self):
         # remove everything except output csv files and submission script
         keep = {"forward_barrier_out.csv", "reverse_barrier_out.csv", "forward_enthalpy_out.csv", "run_egat.sh"}
         for item in self.scratch_dir.iterdir():

--- a/yarp/reaction/external/ts_guess.py
+++ b/yarp/reaction/external/ts_guess.py
@@ -248,7 +248,7 @@ class PysisyphusTSGuessCalculator(TSGuessTask):
         
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Per run dir: keep inputs, logs, xyzs, and trajectories; delete xTB calc dirs."""
         num_runs = self._get_num_runs()
         for i in range(1, num_runs + 1):

--- a/yarp/reaction/external/ts_opt.py
+++ b/yarp/reaction/external/ts_opt.py
@@ -155,7 +155,7 @@ class PysisyphusTSOptCalculator(TSOptTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Per run dir: keep yaml input, log, and final TS geometry; delete Hessian (scraped) and xTB calc dirs."""
         num_runs = self._get_num_runs()
         for i in range(1, num_runs + 1):
@@ -368,7 +368,7 @@ class OrcaTSOptCalculator(TSOptTask):
 
         return True
 
-    def cleanup(self):
+    def _do_cleanup(self):
         """Per run dir: keep inp, output log, and final TS geometry; delete Hessian (scraped), .gbw, .densities, etc."""
         num_runs = self._get_num_runs()
         for i in range(1, num_runs + 1):

--- a/yarp/util/config.py
+++ b/yarp/util/config.py
@@ -1,4 +1,3 @@
-
 import os
 from datetime import datetime
 from dataclasses import dataclass, field
@@ -6,6 +5,7 @@ from typing import List, Optional, Dict
 from pathlib import Path
 
 from yarp.yarpecule.yarpecule import yarpecule
+
 
 def is_valid_time_format(time_str):
     try:
@@ -15,42 +15,53 @@ def is_valid_time_format(time_str):
     except ValueError:
         return False
 
+
 # --- CONFIGURATION OBJECTS ---
 # These classes act as simple containers for user provided settings.
 @dataclass
 class InitalStructConfig:
     """Holds settings for reading in initial species/reactions data."""
+
     source: str = None
     type: str = None
     mode: str = None
 
     def __post_init__(self):
         if self.type not in ["smiles", "xyz", "yarp_pickle"]:
-            raise ValueError(f"Invalid 'type' provided in 'initial_species': {self.type}. Valid options are 'smiles', 'xyz', or 'yarp_pickle'")
+            raise ValueError(
+                f"Invalid 'type' provided in 'initial_species': {self.type}. Valid options are 'smiles', 'xyz', or 'yarp_pickle'"
+            )
         if self.mode not in ["species", "reaction"]:
-            raise ValueError(f"Invalid 'mode' provided in 'initial_species': {self.mode}. Valid options are 'species' or 'reaction'")
+            raise ValueError(
+                f"Invalid 'mode' provided in 'initial_species': {self.mode}. Valid options are 'species' or 'reaction'"
+            )
 
-        if self.type == 'yarp_pickle' and self.mode != 'reaction':
-            raise ValueError(f"Only 'mode = reaction' is valid for 'type = yarp_pickle'")
+        if self.type == "yarp_pickle" and self.mode != "reaction":
+            raise ValueError(
+                f"Only 'mode = reaction' is valid for 'type = yarp_pickle'"
+            )
 
-        if self.type == 'yarp_pickle':
-            if os.path.splitext(self.source)[1].lower() != '.pkl':
+        if self.type == "yarp_pickle":
+            if os.path.splitext(self.source)[1].lower() != ".pkl":
                 raise ValueError(f"'source' must be a .pkl file, got: '{self.source}'")
-            
+
         # TO-DO: Put in checks for XYZ and SMILES, which are compatible with Tanveer's changes
-        #For xyz, initialization is either a directory of .xyz files or single .xyz file. 
-        #Directories are compatible with both species and reaction mode. 
+        # For xyz, initialization is either a directory of .xyz files or single .xyz file.
+        # Directories are compatible with both species and reaction mode.
         if self.type == "xyz":
             source = Path(self.source)
 
             if self.mode == "species":
                 if not (source.is_file() and source.suffix.lower() == ".xyz"):
                     raise ValueError(
-                f"For 'type = xyz' and 'mode = species', 'source' must be .xyz file "
-            )
+                        f"For 'type = xyz' and 'mode = species', 'source' must be .xyz file "
+                    )
 
             if self.mode == "reaction":
-                if not (source.is_dir() or (source.is_file() and source.suffix.lower() == ".xyz")):
+                if not (
+                    source.is_dir()
+                    or (source.is_file() and source.suffix.lower() == ".xyz")
+                ):
                     raise ValueError(
                         f"For 'type = xyz' and 'mode = reaction', 'source' must be either a reaction .xyz file "
                         f"or a directory of reaction .xyz files, got: '{self.source}'"
@@ -60,7 +71,7 @@ class InitalStructConfig:
 
             if self.mode == "species":
                 # species smiles are literal SMILES strings, not files
-                #technically its fine to have a file with a literal SMILES string but lets not. 
+                # technically its fine to have a file with a literal SMILES string but lets not.
                 if source.exists():
                     raise ValueError(
                         f"For 'type = smiles' and 'mode = species', 'source' should be a literal SMILES string, "
@@ -72,9 +83,12 @@ class InitalStructConfig:
                         f"For 'type = smiles' and 'mode = reaction', 'source' must be a file containing mapped "
                         f"reaction SMILES, got: '{self.source}'"
                     )
+
+
 @dataclass
 class JobManagerConfig:
     """Holds settings for job scheduling and container execution."""
+
     scheduler: str = "local"
     container: str = "docker"
     sif_location: Optional[str] = None
@@ -82,7 +96,10 @@ class JobManagerConfig:
     max_active_jobs: int = 100
     queue: Optional[str] = None
     job_name: str = "yarp"
-    account: Optional[str] = None  # Slurm/SGE billing account (e.g. #SBATCH -A on Anvil)
+    account: Optional[str] = (
+        None  # Slurm/SGE billing account (e.g. #SBATCH -A on Anvil)
+    )
+    keep_job_logs: bool = False
 
     def __post_init__(self):
         # Normalize inputs for easier checking
@@ -100,23 +117,32 @@ class JobManagerConfig:
             # .parents[1]    == base_git_repo/yarp
             # .parents[2]    == base_git_repo
             base_repo_path = Path(__file__).resolve().parents[2]
-            
+
             self.sif_location = str(base_repo_path / "containers")
 
         # Sanity Checks
         if self.scheduler not in ["local", "sge", "slurm"]:
-            raise ValueError(f"Invalid 'scheduler' entered: '{self.scheduler}'. Valid options are 'local', 'sge', and 'slurm'")
-        if self.container not in ["apptainer", "docker", 'singularity']:
-            raise ValueError(f"Invalid 'container' entered: '{self.container}'. Valid options are 'apptainer', 'singularity', and 'docker'")
+            raise ValueError(
+                f"Invalid 'scheduler' entered: '{self.scheduler}'. Valid options are 'local', 'sge', and 'slurm'"
+            )
+        if self.container not in ["apptainer", "docker", "singularity"]:
+            raise ValueError(
+                f"Invalid 'container' entered: '{self.container}'. Valid options are 'apptainer', 'singularity', and 'docker'"
+            )
         if self.scheduler in ["sge", "slurm"] and not self.queue:
-            raise ValueError(f"Sanity Check Failed: A 'queue' must be specified when using the '{self.scheduler}' scheduler.")
+            raise ValueError(
+                f"Sanity Check Failed: A 'queue' must be specified when using the '{self.scheduler}' scheduler."
+            )
 
         if not isinstance(self.max_active_jobs, int):
             raise ValueError("Please provide an integer value to 'max_active_jobs'")
         if self.sif_location and not isinstance(self.sif_location, str):
             raise ValueError("Please provide a valid string value to 'sif_location'")
         if self.module_container and not isinstance(self.sif_location, str):
-            raise ValueError("Please provide a valid string value to 'module_container'")
+            raise ValueError(
+                "Please provide a valid string value to 'module_container'"
+            )
+
 
 @dataclass
 class PropertyFilterConfig:
@@ -125,8 +151,11 @@ class PropertyFilterConfig:
     threshold: float
 
     def __post_init__(self):
-        if self.type not in ['barrier', 'reverse_barrier']:
-            raise ValueError(f"Invalid property selected: '{self.type}'. Valid options are 'barrier', 'reverse_barrier'")
+        if self.type not in ["barrier", "reverse_barrier"]:
+            raise ValueError(
+                f"Invalid property selected: '{self.type}'. Valid options are 'barrier', 'reverse_barrier'"
+            )
+
 
 @dataclass
 class ProductBlindersConfig:
@@ -138,8 +167,10 @@ class ProductBlindersConfig:
 
     def __post_init__(self):
         if not self.target_product:
-            raise ValueError("If using product blinders, you must provide a 'target_product'!!!")
-        
+            raise ValueError(
+                "If using product blinders, you must provide a 'target_product'!!!"
+            )
+
         try:
             target = yarpecule(self.target_product)
             target.get_inchi()
@@ -148,17 +179,20 @@ class ProductBlindersConfig:
         except TypeError as e:
             raise ValueError(f"Invalid entry for 'target_product': {e}")
 
+
 @dataclass
 class PreEnumFilters:
     separate_prods: bool = False
     property_filter: Optional[PropertyFilterConfig] = None
     product_blinders: Optional[ProductBlindersConfig] = None
 
+
 @dataclass
 class PostEnumFilters:
     lewis_score: float = 0.0
     formal_charge: float = 2.0
     ring_filter: bool = False
+
 
 @dataclass
 class EnumerationConfig:
@@ -179,7 +213,9 @@ class EnumerationConfig:
 
         # Sanity checks
         if self.mode not in ["concerted", "sequential"]:
-            raise ValueError(f"Invalid enumeration 'mode' entered: '{self.mode}'. Valid options are 'concerted' and 'sequential'")
+            raise ValueError(
+                f"Invalid enumeration 'mode' entered: '{self.mode}'. Valid options are 'concerted' and 'sequential'"
+            )
         if not isinstance(self.n_break, int):
             raise ValueError("Please provide an integer value to 'n_break'")
         if not isinstance(self.n_form, int):
@@ -187,9 +223,12 @@ class EnumerationConfig:
         # TO-DO: Put in sanity checks related to reactive atoms!
 
         # User warnings
-        if self.mode == 'concerted' and self.n_break != self.n_form:
-            print(f"WARNING! Concerted enumeration requires n_break = n_form! Setting n_break = n_form = {self.n_break}")
+        if self.mode == "concerted" and self.n_break != self.n_form:
+            print(
+                f"WARNING! Concerted enumeration requires n_break = n_form! Setting n_break = n_form = {self.n_break}"
+            )
             self.n_form = self.n_break
+
 
 @dataclass
 class GeomSourceConfig:
@@ -205,6 +244,7 @@ class GeomSourceConfig:
         if not self.software or not isinstance(self.software, str):
             raise ValueError("initial_geom source must include a non-empty 'software'")
 
+
 @dataclass
 class InitialGeomConfig:
     reactant: GeomSourceConfig
@@ -212,16 +252,24 @@ class InitialGeomConfig:
     transition_state: GeomSourceConfig
 
     def __post_init__(self):
-        if self.reactant.label not in ['conf_gen', 'rp_opt']:
-            raise ValueError(f"Invalid 'label' for initial_geom.reactant: '{self.reactant.label}'; valid options are 'conf_gen', 'rp_opt'")
-        if self.product.label not in ['conf_gen', 'rp_opt']:
-            raise ValueError(f"Invalid 'label' for initial_geom.product: '{self.product.label}'; valid options are 'conf_gen', 'rp_opt'")
-        if self.transition_state.label not in ['ts_guess', 'ts_opt']:
-            raise ValueError(f"Invalid 'label' for initial_geom.transition_state: '{self.transition_state.label}'; valid options are 'ts_guess', 'ts_opt'")
+        if self.reactant.label not in ["conf_gen", "rp_opt"]:
+            raise ValueError(
+                f"Invalid 'label' for initial_geom.reactant: '{self.reactant.label}'; valid options are 'conf_gen', 'rp_opt'"
+            )
+        if self.product.label not in ["conf_gen", "rp_opt"]:
+            raise ValueError(
+                f"Invalid 'label' for initial_geom.product: '{self.product.label}'; valid options are 'conf_gen', 'rp_opt'"
+            )
+        if self.transition_state.label not in ["ts_guess", "ts_opt"]:
+            raise ValueError(
+                f"Invalid 'label' for initial_geom.transition_state: '{self.transition_state.label}'; valid options are 'ts_guess', 'ts_opt'"
+            )
+
 
 @dataclass
 class MLPropConfig:
     """Holds settings for global ML reaction property predictions."""
+
     model: str
 
     n_cpus: int = 8
@@ -230,21 +278,35 @@ class MLPropConfig:
 
     def __post_init__(self):
         if not self.model:
-            raise ValueError("Missing required key! Please provide 'model' when using ml_rxn_prop method!")
-        if self.model not in ['egat_rgd1']:
-            raise ValueError(f"Invalid 'model' provided: '{self.model}' Currently, only valid option is 'egat_rdg1'")
+            raise ValueError(
+                "Missing required key! Please provide 'model' when using ml_rxn_prop method!"
+            )
+        if self.model not in ["egat_rgd1"]:
+            raise ValueError(
+                f"Invalid 'model' provided: '{self.model}' Currently, only valid option is 'egat_rdg1'"
+            )
         if not isinstance(self.n_cpus, int):
-            raise ValueError("Please provide an integer value to ml_rxn_prop -> 'n_cpus'")
+            raise ValueError(
+                "Please provide an integer value to ml_rxn_prop -> 'n_cpus'"
+            )
         if self.n_cpus < 8:
-            raise ValueError(f"EGAT requires 8 CPUs in order to run safely! Number selected: {self.n_cpus}")
+            raise ValueError(
+                f"EGAT requires 8 CPUs in order to run safely! Number selected: {self.n_cpus}"
+            )
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to ml_rxn_prop -> 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to ml_rxn_prop -> 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
-            raise ValueError("Please provide ml_rxn_prop -> 'max_runtime' time in HH:MM:SS!")
+            raise ValueError(
+                "Please provide ml_rxn_prop -> 'max_runtime' time in HH:MM:SS!"
+            )
+
 
 @dataclass
 class ConformerConfig:
     """Holds settings specific to generating a reactant/product conformers"""
+
     software: str = None
     lot: str = None
     charge: int = None
@@ -259,26 +321,49 @@ class ConformerConfig:
 
     def __post_init__(self):
         if self.charge == None:
-            raise ValueError("Missing required key! Please provide 'charge' in conf_gen block!")
+            raise ValueError(
+                "Missing required key! Please provide 'charge' in conf_gen block!"
+            )
         if not self.software:
-            raise ValueError("Missing required key! Please provide 'software' in conf_gen block!")
-        if self.software not in ['crest']:
-            raise ValueError(f"Invalid 'software' provided: '{self.software}' Currently, only option is 'crest'")
-        if self.software == 'crest' and self.lot not in ['gfn2', 'gfn1', 'gfnff', 'gfn2//gfnff']:
-            raise ValueError(f"Invalid 'lot' for CREST software! Valid options: 'gfn2', 'gfn1', 'gfnff', 'gfn2//gfnff'")
-        if self.software == 'crest' and self.n_unpaired_electrons == None:
-            raise ValueError(f"Missing required key! 'n_unpaired_electrons' field is required for conf_gen with CREST!")
+            raise ValueError(
+                "Missing required key! Please provide 'software' in conf_gen block!"
+            )
+        if self.software not in ["crest"]:
+            raise ValueError(
+                f"Invalid 'software' provided: '{self.software}' Currently, only option is 'crest'"
+            )
+        if self.software == "crest" and self.lot not in [
+            "gfn2",
+            "gfn1",
+            "gfnff",
+            "gfn2//gfnff",
+        ]:
+            raise ValueError(
+                f"Invalid 'lot' for CREST software! Valid options: 'gfn2', 'gfn1', 'gfnff', 'gfn2//gfnff'"
+            )
+        if self.software == "crest" and self.n_unpaired_electrons == None:
+            raise ValueError(
+                f"Missing required key! 'n_unpaired_electrons' field is required for conf_gen with CREST!"
+            )
 
         if not isinstance(self.charge, int):
             raise ValueError("Please provide an integer value to conf_gen: 'charge'")
-        if self.n_unpaired_electrons != None and not isinstance(self.n_unpaired_electrons, int):
-            raise ValueError("Please provide an integer value to conf_gen: 'n_unpaired_electrons'")
+        if self.n_unpaired_electrons != None and not isinstance(
+            self.n_unpaired_electrons, int
+        ):
+            raise ValueError(
+                "Please provide an integer value to conf_gen: 'n_unpaired_electrons'"
+            )
         if not isinstance(self.energy_window, float):
-            raise ValueError("Please provide a float value to conf_gen: 'energy_window'")
+            raise ValueError(
+                "Please provide a float value to conf_gen: 'energy_window'"
+            )
         if not isinstance(self.n_cpus, int):
             raise ValueError("Please provide an integer value to conf_gen: 'n_cpus'")
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to conf_gen: 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to conf_gen: 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
             raise ValueError("Please provide conf_gen: 'max_runtime' time in HH:MM:SS!")
 
@@ -286,6 +371,7 @@ class ConformerConfig:
 @dataclass
 class TSGuessConfig:
     """Holds settings specific to generating transition state guesses via GSM"""
+
     software: str = None
     gsm_lot: str = None
     charge: int = None
@@ -301,29 +387,47 @@ class TSGuessConfig:
 
     def __post_init__(self):
         if self.charge == None:
-            raise ValueError("Missing required key! Please provide 'charge' in ts_guess block!")
+            raise ValueError(
+                "Missing required key! Please provide 'charge' in ts_guess block!"
+            )
         if self.multiplicity == None:
-            raise ValueError("Missing required key! Please provide 'multiplicity' in ts_guess block!")
+            raise ValueError(
+                "Missing required key! Please provide 'multiplicity' in ts_guess block!"
+            )
         if not self.software:
-            raise ValueError("Missing required key! Please provide 'software' in ts_guess block!")
-        if self.software not in ['pysisyphus']:
-            raise ValueError(f"Invalid 'software' provided: '{self.software}' Currently, only option is 'pysisyphus'")
-        if self.software == 'pysisyphus' and self.gsm_lot not in ['xtb']:
-            raise ValueError(f"Invalid 'lot' for Pysisyphus software! Valid options: 'xtb'")
+            raise ValueError(
+                "Missing required key! Please provide 'software' in ts_guess block!"
+            )
+        if self.software not in ["pysisyphus"]:
+            raise ValueError(
+                f"Invalid 'software' provided: '{self.software}' Currently, only option is 'pysisyphus'"
+            )
+        if self.software == "pysisyphus" and self.gsm_lot not in ["xtb"]:
+            raise ValueError(
+                f"Invalid 'lot' for Pysisyphus software! Valid options: 'xtb'"
+            )
 
-        if self.bias_lot not in ['uff', 'Ghemical', 'MMFF94']:
-            raise ValueError(f"Invalid force field selected for 'bias_lot': '{self.bias_lot}' Valid options are: 'uff', 'Ghemical', 'MMFF94'")
-        if self.joint_opt not in ['dual', 'r_only', 'p_only', 'off']:
-            raise ValueError(f"Invalid 'joint_opt' entry: '{self.joint_opt}' Valid options are: 'dual', 'r_only', 'p_only', 'off'")
+        if self.bias_lot not in ["uff", "Ghemical", "MMFF94"]:
+            raise ValueError(
+                f"Invalid force field selected for 'bias_lot': '{self.bias_lot}' Valid options are: 'uff', 'Ghemical', 'MMFF94'"
+            )
+        if self.joint_opt not in ["dual", "r_only", "p_only", "off"]:
+            raise ValueError(
+                f"Invalid 'joint_opt' entry: '{self.joint_opt}' Valid options are: 'dual', 'r_only', 'p_only', 'off'"
+            )
 
         if not isinstance(self.n_conf, int):
             raise ValueError("Please provide an integer value to ts_guess: 'n_conf'")
         if not isinstance(self.max_gsm_nodes, int):
-            raise ValueError("Please provide an integer value to ts_guess: 'max_gsm_nodes'")
+            raise ValueError(
+                "Please provide an integer value to ts_guess: 'max_gsm_nodes'"
+            )
         if not isinstance(self.n_cpus, int):
             raise ValueError("Please provide an integer value to ts_guess: 'n_cpus'")
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to ts_guess: 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to ts_guess: 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
             raise ValueError("Please provide ts_guess: 'max_runtime' time in HH:MM:SS!")
 
@@ -331,6 +435,7 @@ class TSGuessConfig:
 @dataclass
 class RPOptConfig:
     """Holds settings specific to optimizing reactant/product conformers"""
+
     software: str = None
     lot: str = None
     charge: int = None
@@ -346,23 +451,35 @@ class RPOptConfig:
 
     def __post_init__(self):
         if self.charge == None:
-            raise ValueError("Missing required key! Please provide 'charge' in rp_opt block!")
+            raise ValueError(
+                "Missing required key! Please provide 'charge' in rp_opt block!"
+            )
         if self.multiplicity == None:
-            raise ValueError("Missing required key! Please provide 'multiplicity' in rp_opt block!")
-        if self.software not in ['pysisyphus', 'orca']:
-            raise ValueError(f"Invalid rp_opt.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'")
-        if self.software == 'pysisyphus' and self.lot not in ['xtb']:
-            raise ValueError(f"Invalid rp_opt.'lot' for Pysisyphus software! Valid options: 'xtb'")
+            raise ValueError(
+                "Missing required key! Please provide 'multiplicity' in rp_opt block!"
+            )
+        if self.software not in ["pysisyphus", "orca"]:
+            raise ValueError(
+                f"Invalid rp_opt.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'"
+            )
+        if self.software == "pysisyphus" and self.lot not in ["xtb"]:
+            raise ValueError(
+                f"Invalid rp_opt.'lot' for Pysisyphus software! Valid options: 'xtb'"
+            )
         # ERM: To-do -> add a valid input check function for ORCA keyword block?
 
         if not isinstance(self.hessian_recalc, int):
-            raise ValueError("Please provide an integer value to rp_opt: 'hessian_recalc'")
+            raise ValueError(
+                "Please provide an integer value to rp_opt: 'hessian_recalc'"
+            )
         if not isinstance(self.max_cycles, int):
             raise ValueError("Please provide an integer value to rp_opt: 'max_cycles'")
         if not isinstance(self.n_cpus, int):
             raise ValueError("Please provide an integer value to rp_opt: 'n_cpus'")
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to rp_opt: 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to rp_opt: 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
             raise ValueError("Please provide rp_opt: 'max_runtime' time in HH:MM:SS!")
 
@@ -370,13 +487,14 @@ class RPOptConfig:
 @dataclass
 class TSOptConfig:
     """Holds settings specific to optimizing transition state conformers"""
+
     software: str = None
     lot: str = None
     charge: int = None
     multiplicity: int = None
     hessian_recalc: int = 3
     max_cycles: int = 300
-    conv_thresh: str = 'gau' # ERM: only used for xTB right now...
+    conv_thresh: str = "gau"  # ERM: only used for xTB right now...
     initial_geom: Optional[InitialGeomConfig] = None
 
     n_cpus: int = 1
@@ -385,24 +503,36 @@ class TSOptConfig:
 
     def __post_init__(self):
         if self.charge == None:
-            raise ValueError("Missing required key! Please provide 'charge' in ts_opt block!")
+            raise ValueError(
+                "Missing required key! Please provide 'charge' in ts_opt block!"
+            )
         if self.multiplicity == None:
-            raise ValueError("Missing required key! Please provide 'multiplicity' in ts_opt block!")
-        if self.software not in ['pysisyphus', 'orca']:
-            raise ValueError(f"Invalid ts_opt.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'")
-        if self.software == 'pysisyphus' and self.lot not in ['xtb']:
-            raise ValueError(f"Invalid ts_opt.'lot' for Pysisyphus software! Valid options: 'xtb'")
+            raise ValueError(
+                "Missing required key! Please provide 'multiplicity' in ts_opt block!"
+            )
+        if self.software not in ["pysisyphus", "orca"]:
+            raise ValueError(
+                f"Invalid ts_opt.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'"
+            )
+        if self.software == "pysisyphus" and self.lot not in ["xtb"]:
+            raise ValueError(
+                f"Invalid ts_opt.'lot' for Pysisyphus software! Valid options: 'xtb'"
+            )
         # ERM: To-do -> add a valid input check function for ORCA keyword block?
         # ERM: To-do -> look up valid inputs for conv_thresh in xtb!
 
         if not isinstance(self.hessian_recalc, int):
-            raise ValueError("Please provide an integer value to ts_opt: 'hessian_recalc'")
+            raise ValueError(
+                "Please provide an integer value to ts_opt: 'hessian_recalc'"
+            )
         if not isinstance(self.max_cycles, int):
             raise ValueError("Please provide an integer value to ts_opt: 'max_cycles'")
         if not isinstance(self.n_cpus, int):
             raise ValueError("Please provide an integer value to ts_opt: 'n_cpus'")
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to ts_opt: 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to ts_opt: 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
             raise ValueError("Please provide ts_opt: 'max_runtime' time in HH:MM:SS!")
 
@@ -410,12 +540,13 @@ class TSOptConfig:
 @dataclass
 class IRCValConfig:
     """Holds settings specific to validating transition states with IRC"""
+
     software: str = None
     lot: str = None
     charge: int = None
     multiplicity: int = None
     max_cycles: int = 300
-    conv_thresh: str = 'gau' # ERM: only used for xTB right now...
+    conv_thresh: str = "gau"  # ERM: only used for xTB right now...
 
     n_cpus: int = 1
     mem_per_cpu: int = 4000
@@ -423,13 +554,21 @@ class IRCValConfig:
 
     def __post_init__(self):
         if self.charge == None:
-            raise ValueError("Missing required key! Please provide 'charge' in irc_val block!")
+            raise ValueError(
+                "Missing required key! Please provide 'charge' in irc_val block!"
+            )
         if self.multiplicity == None:
-            raise ValueError("Missing required key! Please provide 'multiplicity' in irc_val block!")
-        if self.software not in ['pysisyphus', 'orca']:
-            raise ValueError(f"Invalid irc_val.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'")
-        if self.software == 'pysisyphus' and self.lot not in ['xtb']:
-            raise ValueError(f"Invalid irc_val.'lot' for Pysisyphus software! Valid options: 'xtb'")
+            raise ValueError(
+                "Missing required key! Please provide 'multiplicity' in irc_val block!"
+            )
+        if self.software not in ["pysisyphus", "orca"]:
+            raise ValueError(
+                f"Invalid irc_val.'software' provided: '{self.software}'; valid options: 'pysisyphus', 'orca'"
+            )
+        if self.software == "pysisyphus" and self.lot not in ["xtb"]:
+            raise ValueError(
+                f"Invalid irc_val.'lot' for Pysisyphus software! Valid options: 'xtb'"
+            )
         # ERM: To-do -> add a valid input check function for ORCA keyword block?
         # ERM: To-do -> look up valid inputs for conv_thresh in xtb!
 
@@ -438,6 +577,9 @@ class IRCValConfig:
         if not isinstance(self.n_cpus, int):
             raise ValueError("Please provide an integer value to irc_val: 'n_cpus'")
         if not isinstance(self.mem_per_cpu, int):
-            raise ValueError("Please provide an integer value (in MB) to irc_val: 'mem_per_cpu'")
+            raise ValueError(
+                "Please provide an integer value (in MB) to irc_val: 'mem_per_cpu'"
+            )
         if not is_valid_time_format(self.max_runtime):
             raise ValueError("Please provide irc_val: 'max_runtime' time in HH:MM:SS!")
+


### PR DESCRIPTION
Scheduler stdout/stderr were unconditionally sent to `/dev/null`, so jobs that failed before reaching the container command produced no diagnostic output and then `cleanup()` deletes the scratch directory. I ran into this issue when testing OpenMPI slot-allocation, where failure was invisible. This fix adds a `keep_job_logs` flag on `JobManagerConfig` that redirects scheduler output into the scratch directory and skips cleanup so those logs survive.

`cleanup()` becomes a template method on the base class. This way the flag is checked in one place rather than nine; the nine subclass methods are renamed to` _do_cleanup` with no logic changes.

Note that with this enabled, pysisyphus optimization.h5 files are retained and can reach ~150 MB per GSM run. Users may want to prune those separately.