### PR TITLE
Openbabel fix for fresh calls during optimization and increasing maxiter in quick_geom_opt inside generate_rxns. 

### DIFF
--- a/yarp/reaction/generate_rxns.py
+++ b/yarp/reaction/generate_rxns.py
@@ -210,7 +210,7 @@ def quick_geom_opt(molecule, lot="uff"):
 
     # If RDKit generated a garbage geom, try Open Babel
     if not np.all(rd_diff == 0):
-        ob_opt_g = obabel_ff_opt(molecule, lot=lot)
+        ob_opt_g = obabel_ff_opt(molecule, lot=lot, maxiter=3000)
 
         # If Open Babel fails too, we return None
         ob_adj = table_generator(molecule.elements, ob_opt_g)

--- a/yarp/util/obabel.py
+++ b/yarp/util/obabel.py
@@ -1,8 +1,88 @@
-import os
+import subprocess
+import sys
+import tempfile
+
 import numpy as np
-from openbabel import pybel
 
 from yarp.util.write_files import mol_write_yp
+from yarp.yarpecule.input_parsers import xyz_parse
+
+
+def run_obabel_local_optimization(elements, geo, bond_mat, adj_mat, lot, maxiter):
+    """Optimize one imposed molecular graph with an isolated Open Babel call.
+
+    Parameters
+    ----------
+    elements : sequence
+        Atomic element labels for the molecule.
+    geo : ndarray (N x 3)
+        Starting Cartesian coordinates.
+    bond_mat : ndarray (N x N)
+        Bond-electron matrix to write to the Open Babel MOL input.
+    adj_mat : ndarray (N x N)
+        Adjacency matrix corresponding to ``bond_mat``.
+    lot : str
+        Open Babel force field, for example ``"uff"``.
+    maxiter : int
+        Maximum number of local-optimization steps.
+
+    Returns
+    -------
+    ndarray (N x 3) or None
+        Optimized Cartesian coordinates, or ``None`` when Open Babel cannot
+        produce a readable optimized geometry.
+
+    Notes
+    -----
+    The optimization is run through ``obabel_worker.py`` in a fresh Python
+    process. This prevents native Open Babel force-field state from carrying
+    over between independent YARP candidates.
+    """
+    with tempfile.TemporaryDirectory(prefix="yarp_obabel_") as tmp_dir:
+        input_mol = f"{tmp_dir}/input.mol"
+        output_xyz = f"{tmp_dir}/optimized.xyz"
+
+        # mol_write_yp expects a string, not a pathlib.Path.
+        mol_write_yp(
+            str(input_mol),
+            elements,
+            geo,
+            bond_mat,
+            adj_mat,
+        )
+
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "yarp.util.obabel_worker",
+                    input_mol,
+                    output_xyz,
+                    str(lot),
+                    str(maxiter),
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError:
+            return None
+
+        if result.returncode != 0:
+            return None
+
+        try:
+            out_elements, opt_geom = xyz_parse(output_xyz, multiple=False)
+        except Exception:
+            return None
+
+        if len(out_elements) != len(elements):
+            return None
+
+        return np.asarray(opt_geom, dtype=float)
+
 
 def obabel_ff_opt(molecule, lot="uff", maxiter=500):
     '''
@@ -32,25 +112,15 @@ def obabel_ff_opt(molecule, lot="uff", maxiter=500):
         - 'mmff94' : Merck Molecular Force Field, better for organics
         - 'ghemical' : simpler/faster, less accurate
     '''
+    return run_obabel_local_optimization(
+        molecule.elements,
+        molecule.geo,
+        molecule.bond_mats[0],
+        molecule.adj_mat,
+        lot,
+        maxiter,
+    )
 
-    # Write yarpecule object to a temporary mol file
-    mol_file = '.tmp.mol'
-    mol_write_yp(mol_file, molecule.elements, molecule.geo,
-                 molecule.bond_mats[0], molecule.adj_mat)
-
-    # Use openbabel to perform geometry optimization
-    mol = next(pybel.readfile("mol", mol_file))
-    mol.localopt(forcefield=lot, steps=maxiter)
-
-    # Delete temporary mol file
-    os.system("rm {}".format(mol_file))
-
-    # Collect optimized geometry coordinates
-    opt_geom = np.zeros_like(molecule.geo)
-    for count_i, i in enumerate(opt_geom):
-        opt_geom[count_i] = mol.atoms[count_i].coords
-
-    return opt_geom
 
 def obabel_joint_opt(conformer, target_bem, target_adj, lot="uff", maxiter=500):
     '''
@@ -87,20 +157,11 @@ def obabel_joint_opt(conformer, target_bem, target_adj, lot="uff", maxiter=500):
     pybel's `localopt`, so both fallbacks behave identically instead of
     diverging on which part of the Open Babel API they happen to call.
     '''
-    mol_file = '.tmp_joint.mol'
-    try:
-        mol_write_yp(mol_file, conformer.elements, conformer.geo, target_bem, target_adj)
-
-        mol = next(pybel.readfile("mol", mol_file))
-        mol.localopt(forcefield=lot, steps=maxiter)
-
-        opt_geo = np.zeros_like(conformer.geo)
-        for count_i, i in enumerate(opt_geo):
-            opt_geo[count_i] = mol.atoms[count_i].coords
-
-        return opt_geo
-    except (ValueError, RuntimeError):
-        return None
-    finally:
-        if os.path.exists(mol_file):
-            os.remove(mol_file)
+    return run_obabel_local_optimization(
+        conformer.elements,
+        conformer.geo,
+        target_bem,
+        target_adj,
+        lot,
+        maxiter,
+    )

--- a/yarp/util/obabel_worker.py
+++ b/yarp/util/obabel_worker.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Run exactly one Open Babel local optimization in an isolated process."""
+
+import sys
+from openbabel import pybel
+
+
+def main(argv):
+    # argv:
+    #   0: this script
+    #   1: input MOL file
+    #   2: output XYZ file
+    #   3: force field, e.g. "uff"
+    #   4: maximum number of steps
+    if len(argv) != 5:
+        raise SystemExit(
+            "usage: obabel_worker.py INPUT_MOL OUTPUT_XYZ FORCEFIELD STEPS"
+        )
+
+    input_mol = argv[1]
+    output_xyz = argv[2]
+    forcefield = argv[3]
+    steps = int(argv[4])
+
+    mol = next(pybel.readfile("mol", input_mol))
+    mol.localopt(forcefield=forcefield, steps=steps)
+    mol.write("xyz", output_xyz, overwrite=True)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
After putting maxiter in gen_rxns we get 37 products in round 1 both in obabel fix and also without. 
In round2: 
    Reactions present after obabel fix 1168.
    Reactions present before obabel fix 1162. 

Reactions recovered after obabel fix are: 

| Reaction hash | Reactant | Product|
|---|---|---|
| `2696810.4632272627` | `C=C=O.COO` | `CO.O=C=CO` |
| `2818208.1970234127` | `C=C.O=COO` | `C=CO.O=CO` |
| `2818316.616878682` | `C=COO.C=O` | `C=CO.O=CO` |
| `2839997.699206396` | `C=COO.C=O` | `C=C1OO1.C=O.[H][H]` |
| `3422375.007988056` | `O=C(O)CCO` | `O=COCCO` |
| `3967630.6566044134` | `O[C@H]1CCOO1` | `O/C=C/COO` |


All reactions skipped in round 2 of enumeration before the fix was applied: 

1. + SKIPPED! Unable to form valid product (C=C1O[C@H]1OO.[H][H]) geom from reactant (C=COCOO) geom
2. + SKIPPED! Unable to form valid product (CO.O=C=CO) geom from reactant (C=C=O.COO) geom
3. + SKIPPED! Unable to form valid product (C=CO.O=CO) geom from reactant (C=C.O=COO) geom
4. + SKIPPED! Unable to form valid product (C=C.O=C1OO1.[H][H]) geom from reactant (C=C.O=COO) geom
5. + SKIPPED! Unable to form valid product (C=C1OO1.C=O.[H][H]) geom from reactant (C=COO.C=O) geom
6. + SKIPPED! Unable to form valid product (C=CO.O=CO) geom from reactant (C=COO.C=O) geom
7. + SKIPPED! Unable to form valid product (C=C1OO1.C=O.[H][H]) geom from reactant (O=CCC1OO1.[H][H]) geom
8. + SKIPPED! Unable to form valid product (C=COCOO) geom from reactant (O/C=C/COO) geom
9. + SKIPPED! Unable to form valid product (C/C=C(/O)OO) geom from reactant (O/C=C/COO) geom
10. + SKIPPED! Unable to form valid product (O/C=C/COO) geom from reactant (O[C@H]1CCOO1) geom
11. + SKIPPED! Unable to form valid product (O=COCCO) geom from reactant (O=C(O)CCO) geom
12. + SKIPPED! Unable to form valid product (C=C1OCOO1.[H][H]) geom from reactant (O=C1CCOO1.[H][H]) geom


The skip of interest to us is 3: 

+ SKIPPED! Unable to form valid product (C=CO.O=CO) geom from reactant (C=C.O=COO) geom
Because this is reaction 7 > 96 as reported in yarp supplementary information. 


The 5 other skips that were also recovered :

2. + SKIPPED! Unable to form valid product (CO.O=C=CO) geom from reactant (C=C=O.COO) geom
6. + SKIPPED! Unable to form valid product (C=CO.O=CO) geom from reactant (C=COO.C=O) geom
5. + SKIPPED! Unable to form valid product (C=C1OO1.C=O.[H][H]) geom from reactant (C=COO.C=O) geom
11. + SKIPPED! Unable to form valid product (O=COCCO) geom from reactant (O=C(O)CCO) geom
10. + SKIPPED! Unable to form valid product (O/C=C/COO) geom from reactant (O[C@H]1CCOO1) geom