### PR TITLE
Shared atom bond events for b2f2 reactions. 

### DIFF
--- a/helper/read_pkl.py
+++ b/helper/read_pkl.py
@@ -6,6 +6,8 @@ Default output:
 
 Options:
     -i, --ids       Include reaction hashes.
+    -H, --endpoint-hashes
+                    Include reactant and product yarpecule hashes.
     -f, --forward   Include all levels in rxn.barrier.
     -r, --reverse   Include all levels in rxn.reverse_barrier.
     -g, --dg        Include all levels in rxn.dg_rxn.
@@ -18,7 +20,7 @@ Options:
 Short flags can be combined, e.g. -ifrg.
 
 Usage:
-    python read_pkl.py [-ifrgba] [--visualize] yarp.pkl
+    python read_pkl.py [-ifrgbaH] [--visualize] yarp.pkl
 """
 import argparse
 import os
@@ -156,6 +158,9 @@ def main(args):
     headers = ["Reactant", "Product"]
     if args.ids:
         headers.insert(0, "Reaction Hash")
+    if args.endpoint_hashes:
+        insert_at = 1 if args.ids else 0
+        headers[insert_at:insert_at] = ["Reactant Hash", "Product Hash"]
     for direction, _, label, key in columns:
         headers.append(f"{key} {direction} {label}")
     if args.meta:
@@ -169,6 +174,12 @@ def main(args):
         ]
         if args.ids:
             row.insert(0, getattr(rxn, "hash", "none"))
+        if args.endpoint_hashes:
+            insert_at = 1 if args.ids else 0
+            row[insert_at:insert_at] = [
+                getattr(rxn.reactant, "hash", "none"),
+                getattr(rxn.product, "hash", "none"),
+            ]
 
         for _, attr, _, key in columns:
             row.append(_format_optional_value(_reaction_value(rxn, attr, key)))
@@ -188,6 +199,8 @@ def main(args):
 def _add_options(parser):
     parser.add_argument("-i", "--ids", action="store_true",
                         help="Include reaction hashes as the first table column.")
+    parser.add_argument("-H", "--endpoint-hashes", action="store_true",
+                        help="Include reactant and product yarpecule hash columns.")
     parser.add_argument("--visualize", action="store_true",
                         help="Write reactant/product BEM PDFs for each reaction.")
     parser.add_argument("--visual-dir", default="visuals",
@@ -222,6 +235,7 @@ def cli():
 
             Flag summary:
               -i  add reaction hash column
+              -H  add reactant and product yarpecule hash columns
               -f  show all forward barrier columns from rxn.barrier
               -r  show all reverse barrier columns from rxn.reverse_barrier
               -g  show all reaction dG columns from rxn.dg_rxn
@@ -236,6 +250,7 @@ def cli():
             Examples:
               python read_pkl.py yarp.pkl
               python read_pkl.py -i yarp.pkl
+              python read_pkl.py -iH yarp.pkl
               python read_pkl.py -ifrg yarp.pkl
               python read_pkl.py --limit 25 yarp.pkl
               python read_pkl.py -ia --tablefmt github yarp.pkl

--- a/yarp/reaction/enum.py
+++ b/yarp/reaction/enum.py
@@ -11,6 +11,10 @@ from typing import Iterable, Tuple
 from yarp.yarpecule.lewis.bem_score import return_formals
 from yarp.yarpecule.yarpecule import yarpecule
 from yarp.util.misc import prepare_list, merge_arrays
+from yarp.reaction.enum_support import (
+    apply_legacy_shared_atom_b2f2,
+    legacy_shared_atom_b2f2_changes,
+)
 
 def _reactive_maps_from_react(react):
     """
@@ -676,12 +680,31 @@ def bnfn(yarpecules, n, react=[], hashes=None, hash_filter=False, lower_score=Fa
                 print("Bond matrix after breaking bonds:")
                 print(base_bmat)
 
+            # A repeated B2F2 endpoint can represent the legacy shared-atom
+            # bond/electron rearrangement, so identify it before ordinary
+            # pairing treats the repeated endpoint as a dangling bond.
+            shared_atom_changes = legacy_shared_atom_b2f2_changes(
+                n, formset, radicals, y.lewis.bond_mats[fc_ind], y.elements
+            )
+
             # Loop over all unique ways to pair reactive atoms into new bonds
+            if shared_atom_changes is not None:
+                formation_changes = [
+                    (change.bonds_to_form, change)
+                    for change in shared_atom_changes
+                ]
+            else:
+                formation_changes = [
+                    (formation, None)
+                    for formation in unique_set_partition_generator(formset, 2)
+                ]
+
             if debug:
                 print(f"this is the formset: {formset}")
                 print(f"these are the bond formations we will test: "
-                      f"{list(unique_set_partition_generator(formset, 2))}")
-            for g in unique_set_partition_generator(formset, 2):
+                      f"{[formation for formation, _ in formation_changes]}")
+
+            for g, shared_atom_change in formation_changes:
 
                 # Skip if we would just reform a bond we broke
                 if frozenset(g) in avoid:
@@ -699,10 +722,34 @@ def bnfn(yarpecules, n, react=[], hashes=None, hash_filter=False, lower_score=Fa
                 if debug:
                     print(f"Forming bonds: {[y.describe_atom_pair(_) for _ in g]}")
 
-                # Create new adjacency matrix by adding the new bonds
-                adj_mat = copy(base_bmat)
+                if shared_atom_change is not None:
+                    if debug:
+                        print(
+                            "Legacy shared-atom criterion: "
+                            f"{shared_atom_change.criterion}"
+                        )
+                    # Mirror the complete legacy special case at the BEM level:
+                    # account for electrons released/consumed by bond changes,
+                    # then move the donor's electron pair to the shared atom.
+                    product_bmat = apply_legacy_shared_atom_b2f2(
+                        y.lewis.bond_mats[fc_ind],
+                        [bonds[_] for _ in b],
+                        shared_atom_change,
+                    )
+                    if debug:
+                        print("Bond matrix after legacy electron redistribution:")
+                        print(product_bmat)
+                else:
+                    product_bmat = copy(base_bmat)
+                    product_bmat = add_bonds(
+                        product_bmat, [list(_) for _ in g], val=1
+                    )
+
+                # Current YARP constructs a product from connectivity and then
+                # determines its Lewis structures. Convert the redistributed
+                # BEM only after all legacy BEM operations are complete.
+                adj_mat = np.where(product_bmat > 0, 1, 0).astype(int)
                 np.fill_diagonal(adj_mat, 0)
-                adj_mat = add_bonds(adj_mat, [list(_) for _ in g], val=1)
 
                 # Create new yarpecule product. The np.where is used to convert the bond matrix to an adjacency matrix.
                 product = yarpecule((
@@ -727,7 +774,10 @@ def bnfn(yarpecules, n, react=[], hashes=None, hash_filter=False, lower_score=Fa
                     print(f"New adjacency matrix:\n{product._adj_mat}")
 
                 # Optional: skip products with higher bond matrix scores (worse quality)
-                if lower_score:
+                # The legacy shared-atom route predates the current Lewis-score gate;
+                # applying that gate here removes the intended CO-containing product.
+
+                if lower_score and shared_atom_change is None:
                     if product.lewis._scores[0] > y.lewis._scores[0]:
                         if debug:
                             print(f"Skipping - higher score: "

--- a/yarp/reaction/enum_support.py
+++ b/yarp/reaction/enum_support.py
@@ -1,0 +1,117 @@
+"""Support functions for reaction enumeration."""
+
+from collections import Counter
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SharedAtomB2F2Change:
+    """One legacy shared-atom B2F2 bond/electron rearrangement."""
+
+    bonds_to_form: tuple
+    shared_atom: int
+    electron_donor: int
+    criterion: str
+
+
+def legacy_shared_atom_b2f2_changes(n, formset, radicals, bond_mat, elements):
+    """Return strict and loose legacy changes for a shared-atom B2F2 step.
+
+    ``None`` means the two broken bonds are not a shared-atom special case. An
+    empty tuple means that they are a shared-atom case, but no untouched
+    neighbour satisfies either applicable legacy lone-pair criterion.
+
+    ``elements`` is required because the loose criterion must distinguish
+    hydrogens from heavy atoms and compare the donor and shared-atom elements.
+    """
+    if n != 2 or radicals:
+        return None
+
+    shared_atoms = [
+        atom for atom, count in Counter(formset).items() if count > 1
+    ]
+    if len(shared_atoms) != 1:
+        return None
+
+    shared_atom = shared_atoms[0]
+    non_shared_atoms = [atom for atom in formset if atom != shared_atom]
+    if len(non_shared_atoms) != 2 or len(set(non_shared_atoms)) != 2:
+        return ()
+
+    changes = []
+    for neighbor, bond_order in enumerate(bond_mat[shared_atom]):
+        if neighbor == shared_atom or bond_order <= 0 or neighbor in formset:
+            continue
+
+        other_connections = [
+            atom
+            for atom, order in enumerate(bond_mat[neighbor])
+            if atom not in (neighbor, shared_atom) and order > 0
+        ]
+        has_lone_electrons = bond_mat[neighbor, neighbor] > 0
+        strict_match = not other_connections and has_lone_electrons
+
+        heavy_connections = [
+            atom
+            for atom in other_connections
+            if elements[atom].lower() != "h"
+        ]
+        loose_match = (
+            len(other_connections) < 3
+            and not heavy_connections
+            and elements[neighbor].lower() != elements[shared_atom].lower()
+            and has_lone_electrons
+        )
+
+        if strict_match or loose_match:
+            if strict_match and loose_match:
+                criterion = "strict+loose"
+            elif strict_match:
+                criterion = "strict"
+            else:
+                criterion = "loose"
+            changes.append(
+                SharedAtomB2F2Change(
+                    bonds_to_form=(
+                        frozenset(non_shared_atoms),
+                        frozenset((shared_atom, neighbor)),
+                    ),
+                    shared_atom=shared_atom,
+                    electron_donor=neighbor,
+                    criterion=criterion,
+                )
+            )
+
+    return tuple(changes)
+
+
+def apply_legacy_shared_atom_b2f2(bond_mat, bonds_to_break, change):
+    """Apply the complete legacy shared-atom B2F2 BEM transformation.
+
+    The legacy implementation first returns one electron to each endpoint of
+    every broken bond, consumes one electron from each endpoint of every formed
+    bond, and finally transfers an electron pair from the untouched terminal
+    neighbour to the shared atom.
+    """
+    product_bmat = np.array(bond_mat, copy=True)
+
+    for bond in bonds_to_break:
+        atom_i, atom_j = bond[:2]
+        product_bmat[atom_i, atom_j] -= 1
+        product_bmat[atom_j, atom_i] -= 1
+        product_bmat[atom_i, atom_i] += 1
+        product_bmat[atom_j, atom_j] += 1
+
+    for bond in change.bonds_to_form:
+        atom_i, atom_j = tuple(bond)
+        product_bmat[atom_i, atom_j] += 1
+        product_bmat[atom_j, atom_i] += 1
+        product_bmat[atom_i, atom_i] -= 1
+        product_bmat[atom_j, atom_j] -= 1
+
+    product_bmat[change.electron_donor, change.electron_donor] -= 2
+    product_bmat[change.shared_atom, change.shared_atom] += 2
+
+    return product_bmat


### PR DESCRIPTION
Round 1 enumeration

```
initialize:
  verbose: True
  output: cyc1.pkl
  status: cyc1_STATUS.json
  initial_structure:
    source: 'O=CCCOO'
    type: smiles
    mode: species
  job_manager:
     scheduler: local
     container: docker
     max_active_jobs: 2
  enumeration:
    mode: concerted
    n_break: 2
    n_form: 2
    post_enum_filters:
      lewis_score: 0.2
      formal_charge: 2.5
      ring_filter: False
```
python helper/read_pkl.py cyc1.pkl >> round1_reactions.txt
There should be 38 unique products returned for round 1. (checked with hash_filter = False) All round1 products reported in original paper are successfully recovered. 

Round 2 enumeration

```
initialize:
  verbose: True
  output: cyc2.pkl
  status: cyc2_STATUS.json
  initial_structure:
    source: cyc1.pkl
    type: yarp_pickle
    mode: reaction 
  job_manager:
     scheduler: local
     container: docker
     max_active_jobs: 2
  enumeration:
    mode: concerted
    n_break: 2
    n_form: 2
    post_enum_filters:
      lewis_score: 0.2
      formal_charge: 2.5
      ring_filter: False
```
python helper/read_pkl.py cyc1.pkl >> round2_reactions.txt

This should show 1252 reactions recovered in round 2. 
cat round1_reactions.txt round2_reactions.txt >> all_reactions.txt 

Paper_173_channel_xyz_canonical_hashes.txt contain the canonical hashes of reactant and product of all 173 reaction channels originally recovered in the yarp paper. The initialization was done from the reported xyzs as reported smiles strings had some issues. 

match_round1_hashes_to_paper.py all_reactions.txt paper_173_channel_xyz_canonical_hashes.txt

This would still show 10 missing reaction channels.

Pathology 1: 
7 > 95
8 > 95
20 > 95
25 > 95
8 > 109
These reactions exist but under a different bond electron matrix. The products when initialized with canon = True have two resonance structures which changes the BEM hash. All 5 intended reactions are actually present. (Verified individually) 

Pathology2: 
3 > 65
The reported xyz from which the yarpecule was initialized and hash was extracted fails to give the right adjacency. The actual reported reaction in the paper is recovered still. 

Pathology 3: 
19>119 
This is the only reaction the adjacency check after quick_geom_opt() throws out. This is likely an initial geometry problem because when the enumeration is ran separately from a smiles string of 19 and not as a round 2 enumeration product 119 is successfully recovered. 

Pathology4: 
1 > 7
1 > 12
14 > 15 
These reactions get overwritten by their reverse reactions. Normally, a reverse reaction should have a different hash than the forward reaction. And this can be verified from the existence of both forward and reverse reactions in the final output. However, for these three cases the forward and backward produce the exact same hash unexpectedly. 

So more importantly, the 19 reaction channels that were missing due to the overly restrictive due to dangling bond check have been recovered in all_reactions.txt 
[all_reactions.txt](https://github.com/user-attachments/files/32096203/all_reactions.txt)


Reaction | Line
-- | --
0→16 | 29 
5→85 | 267 
5→87 | 276 
16→87 | 807 
7→98 | 351 
8→98 | 370 
16→98 | 810 
12→127 | 582 
13→127 | 611 
16→127 | 814 
14→139 | 724 
16→139 | 817 
16→149 | 812 
16→150 | 815 
16→152 | 820 
19→152 | 962 
22→152 | 1173 
16→153 | 821
16→155 | 825 

As expected, pytest failures are seen due to these changes. The failures are consistent with the changes made. 

```
=========================== short test summary info ============================
FAILED test/reaction/test_enum.py::TestConcertedClosedShell::test_haa_b2f2_exact
FAILED test/reaction/test_enum.py::TestConcertedClosedShell::test_haa_b3f3_contains_b2f2
FAILED test/reaction/test_enum.py::TestConcertedClosedShell::test_khp_b3f3_contains_b2f2
======================== 3 failed, 137 passed in 41.09s ========================
```


[paper_173_channel_xyz_canonical_hashes.txt](https://github.com/user-attachments/files/32095043/paper_173_channel_xyz_canonical_hashes.txt)
[match_round1_hashes_to_paper.py](https://github.com/user-attachments/files/32095144/match_round1_hashes_to_paper.py)



